### PR TITLE
fix: useEmptySlot

### DIFF
--- a/packages/world/test/InventoryUtils.t.sol
+++ b/packages/world/test/InventoryUtils.t.sol
@@ -137,4 +137,23 @@ contract InventoryUtilsTest is DustTest {
       assertEq(i, slotData.occupiedIndex, "Wrong occupied index");
     }
   }
+
+  function testDuplicateOccupiedSlotsWhenUsingNonSequentialEmptySlots() public {
+    (, EntityId aliceEntity) = createTestPlayer(vec3(0, 0, 0));
+
+    TestInventoryUtils.addEntity(aliceEntity, ObjectTypes.WoodenHoe); // slot 0
+    TestInventoryUtils.addObjectToSlot(aliceEntity, ObjectTypes.Ice, 1, 2); // slot 2
+
+    // This will use an empty slot
+    TestInventoryUtils.addObject(aliceEntity, ObjectTypes.Snow, 1);
+
+    uint16[] memory slots = Inventory.get(aliceEntity);
+    assertEq(slots.length, 3, "expected 3 occupied-slot entries");
+
+    // All slots should be unique and correct
+    for (uint256 i = 0; i < slots.length; i++) {
+      InventorySlotData memory slotData = InventorySlot.get(aliceEntity, slots[i]);
+      assertEq(i, slotData.occupiedIndex, "Wrong occupied index");
+    }
+  }
 }


### PR DESCRIPTION
Will try to come up with a more efficient way of finding empty slots, wip

tldr of the issue:
If you did the following actions:
- Add object to inventory without specifying slot (uses slot 0)
- Add object to slot 2
- Add another object without specifying slot

This would result in duplicated occupiedIndex for slot 2, as `useEmptySlot` was incorrectly using the occupiedIndex length as the slot to add.