### PR TITLE
Clean up, add more tests, efficient tracking of empty slots

### DIFF
--- a/packages/world/mud.config.ts
+++ b/packages/world/mud.config.ts
@@ -202,6 +202,7 @@ export default defineWorld({
     Inventory: {
       schema: {
         owner: "EntityId",
+        nextSlot: "uint16", // Next available slot
         occupiedSlots: "uint16[]", // Slots with at least 1 item
       },
       key: ["owner"],
@@ -213,7 +214,6 @@ export default defineWorld({
         entityId: "EntityId",
         objectType: "ObjectType",
         amount: "uint16",
-        // TODO: we could make them bigger but not sure if neeed
         occupiedIndex: "uint16",
         typeIndex: "uint16", // Index in InventoryTypeSlots
       },

--- a/packages/world/src/codegen/index.sol
+++ b/packages/world/src/codegen/index.sol
@@ -17,7 +17,7 @@ import { ExploredChunk } from "./tables/ExploredChunk.sol";
 import { SurfaceChunkByIndex, SurfaceChunkByIndexData } from "./tables/SurfaceChunkByIndex.sol";
 import { SurfaceChunkCount } from "./tables/SurfaceChunkCount.sol";
 import { RegionMerkleRoot } from "./tables/RegionMerkleRoot.sol";
-import { Inventory } from "./tables/Inventory.sol";
+import { Inventory, InventoryData } from "./tables/Inventory.sol";
 import { InventorySlot, InventorySlotData } from "./tables/InventorySlot.sol";
 import { InventoryTypeSlots } from "./tables/InventoryTypeSlots.sol";
 import { MovablePosition, MovablePositionData } from "./tables/MovablePosition.sol";

--- a/packages/world/src/codegen/tables/Inventory.sol
+++ b/packages/world/src/codegen/tables/Inventory.sol
@@ -19,17 +19,22 @@ import { ResourceId } from "@latticexyz/store/src/ResourceId.sol";
 // Import user types
 import { EntityId } from "../../EntityId.sol";
 
+struct InventoryData {
+  uint16 nextSlot;
+  uint16[] occupiedSlots;
+}
+
 library Inventory {
   // Hex below is the result of `WorldResourceIdLib.encode({ namespace: "", name: "Inventory", typeId: RESOURCE_TABLE });`
   ResourceId constant _tableId = ResourceId.wrap(0x74620000000000000000000000000000496e76656e746f727900000000000000);
 
   FieldLayout constant _fieldLayout =
-    FieldLayout.wrap(0x0000000100000000000000000000000000000000000000000000000000000000);
+    FieldLayout.wrap(0x0002010102000000000000000000000000000000000000000000000000000000);
 
   // Hex-encoded key schema of (bytes32)
   Schema constant _keySchema = Schema.wrap(0x002001005f000000000000000000000000000000000000000000000000000000);
-  // Hex-encoded value schema of (uint16[])
-  Schema constant _valueSchema = Schema.wrap(0x0000000163000000000000000000000000000000000000000000000000000000);
+  // Hex-encoded value schema of (uint16, uint16[])
+  Schema constant _valueSchema = Schema.wrap(0x0002010101630000000000000000000000000000000000000000000000000000);
 
   /**
    * @notice Get the table's key field names.
@@ -45,8 +50,9 @@ library Inventory {
    * @return fieldNames An array of strings with the names of value fields.
    */
   function getFieldNames() internal pure returns (string[] memory fieldNames) {
-    fieldNames = new string[](1);
-    fieldNames[0] = "occupiedSlots";
+    fieldNames = new string[](2);
+    fieldNames[0] = "nextSlot";
+    fieldNames[1] = "occupiedSlots";
   }
 
   /**
@@ -64,6 +70,48 @@ library Inventory {
   }
 
   /**
+   * @notice Get nextSlot.
+   */
+  function getNextSlot(EntityId owner) internal view returns (uint16 nextSlot) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = EntityId.unwrap(owner);
+
+    bytes32 _blob = StoreSwitch.getStaticField(_tableId, _keyTuple, 0, _fieldLayout);
+    return (uint16(bytes2(_blob)));
+  }
+
+  /**
+   * @notice Get nextSlot.
+   */
+  function _getNextSlot(EntityId owner) internal view returns (uint16 nextSlot) {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = EntityId.unwrap(owner);
+
+    bytes32 _blob = StoreCore.getStaticField(_tableId, _keyTuple, 0, _fieldLayout);
+    return (uint16(bytes2(_blob)));
+  }
+
+  /**
+   * @notice Set nextSlot.
+   */
+  function setNextSlot(EntityId owner, uint16 nextSlot) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = EntityId.unwrap(owner);
+
+    StoreSwitch.setStaticField(_tableId, _keyTuple, 0, abi.encodePacked((nextSlot)), _fieldLayout);
+  }
+
+  /**
+   * @notice Set nextSlot.
+   */
+  function _setNextSlot(EntityId owner, uint16 nextSlot) internal {
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = EntityId.unwrap(owner);
+
+    StoreCore.setStaticField(_tableId, _keyTuple, 0, abi.encodePacked((nextSlot)), _fieldLayout);
+  }
+
+  /**
    * @notice Get occupiedSlots.
    */
   function getOccupiedSlots(EntityId owner) internal view returns (uint16[] memory occupiedSlots) {
@@ -78,28 +126,6 @@ library Inventory {
    * @notice Get occupiedSlots.
    */
   function _getOccupiedSlots(EntityId owner) internal view returns (uint16[] memory occupiedSlots) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = EntityId.unwrap(owner);
-
-    bytes memory _blob = StoreCore.getDynamicField(_tableId, _keyTuple, 0);
-    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint16());
-  }
-
-  /**
-   * @notice Get occupiedSlots.
-   */
-  function get(EntityId owner) internal view returns (uint16[] memory occupiedSlots) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = EntityId.unwrap(owner);
-
-    bytes memory _blob = StoreSwitch.getDynamicField(_tableId, _keyTuple, 0);
-    return (SliceLib.getSubslice(_blob, 0, _blob.length).decodeArray_uint16());
-  }
-
-  /**
-   * @notice Get occupiedSlots.
-   */
-  function _get(EntityId owner) internal view returns (uint16[] memory occupiedSlots) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = EntityId.unwrap(owner);
 
@@ -128,26 +154,6 @@ library Inventory {
   }
 
   /**
-   * @notice Set occupiedSlots.
-   */
-  function set(EntityId owner, uint16[] memory occupiedSlots) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = EntityId.unwrap(owner);
-
-    StoreSwitch.setDynamicField(_tableId, _keyTuple, 0, EncodeArray.encode((occupiedSlots)));
-  }
-
-  /**
-   * @notice Set occupiedSlots.
-   */
-  function _set(EntityId owner, uint16[] memory occupiedSlots) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = EntityId.unwrap(owner);
-
-    StoreCore.setDynamicField(_tableId, _keyTuple, 0, EncodeArray.encode((occupiedSlots)));
-  }
-
-  /**
    * @notice Get the length of occupiedSlots.
    */
   function lengthOccupiedSlots(EntityId owner) internal view returns (uint256) {
@@ -164,32 +170,6 @@ library Inventory {
    * @notice Get the length of occupiedSlots.
    */
   function _lengthOccupiedSlots(EntityId owner) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = EntityId.unwrap(owner);
-
-    uint256 _byteLength = StoreCore.getDynamicFieldLength(_tableId, _keyTuple, 0);
-    unchecked {
-      return _byteLength / 2;
-    }
-  }
-
-  /**
-   * @notice Get the length of occupiedSlots.
-   */
-  function length(EntityId owner) internal view returns (uint256) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = EntityId.unwrap(owner);
-
-    uint256 _byteLength = StoreSwitch.getDynamicFieldLength(_tableId, _keyTuple, 0);
-    unchecked {
-      return _byteLength / 2;
-    }
-  }
-
-  /**
-   * @notice Get the length of occupiedSlots.
-   */
-  function _length(EntityId owner) internal view returns (uint256) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = EntityId.unwrap(owner);
 
@@ -228,34 +208,6 @@ library Inventory {
   }
 
   /**
-   * @notice Get an item of occupiedSlots.
-   * @dev Reverts with Store_IndexOutOfBounds if `_index` is out of bounds for the array.
-   */
-  function getItem(EntityId owner, uint256 _index) internal view returns (uint16) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = EntityId.unwrap(owner);
-
-    unchecked {
-      bytes memory _blob = StoreSwitch.getDynamicFieldSlice(_tableId, _keyTuple, 0, _index * 2, (_index + 1) * 2);
-      return (uint16(bytes2(_blob)));
-    }
-  }
-
-  /**
-   * @notice Get an item of occupiedSlots.
-   * @dev Reverts with Store_IndexOutOfBounds if `_index` is out of bounds for the array.
-   */
-  function _getItem(EntityId owner, uint256 _index) internal view returns (uint16) {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = EntityId.unwrap(owner);
-
-    unchecked {
-      bytes memory _blob = StoreCore.getDynamicFieldSlice(_tableId, _keyTuple, 0, _index * 2, (_index + 1) * 2);
-      return (uint16(bytes2(_blob)));
-    }
-  }
-
-  /**
    * @notice Push an element to occupiedSlots.
    */
   function pushOccupiedSlots(EntityId owner, uint16 _element) internal {
@@ -276,26 +228,6 @@ library Inventory {
   }
 
   /**
-   * @notice Push an element to occupiedSlots.
-   */
-  function push(EntityId owner, uint16 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = EntityId.unwrap(owner);
-
-    StoreSwitch.pushToDynamicField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
-  }
-
-  /**
-   * @notice Push an element to occupiedSlots.
-   */
-  function _push(EntityId owner, uint16 _element) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = EntityId.unwrap(owner);
-
-    StoreCore.pushToDynamicField(_tableId, _keyTuple, 0, abi.encodePacked((_element)));
-  }
-
-  /**
    * @notice Pop an element from occupiedSlots.
    */
   function popOccupiedSlots(EntityId owner) internal {
@@ -309,26 +241,6 @@ library Inventory {
    * @notice Pop an element from occupiedSlots.
    */
   function _popOccupiedSlots(EntityId owner) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = EntityId.unwrap(owner);
-
-    StoreCore.popFromDynamicField(_tableId, _keyTuple, 0, 2);
-  }
-
-  /**
-   * @notice Pop an element from occupiedSlots.
-   */
-  function pop(EntityId owner) internal {
-    bytes32[] memory _keyTuple = new bytes32[](1);
-    _keyTuple[0] = EntityId.unwrap(owner);
-
-    StoreSwitch.popFromDynamicField(_tableId, _keyTuple, 0, 2);
-  }
-
-  /**
-   * @notice Pop an element from occupiedSlots.
-   */
-  function _pop(EntityId owner) internal {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = EntityId.unwrap(owner);
 
@@ -362,29 +274,131 @@ library Inventory {
   }
 
   /**
-   * @notice Update an element of occupiedSlots at `_index`.
+   * @notice Get the full data.
    */
-  function update(EntityId owner, uint256 _index, uint16 _element) internal {
+  function get(EntityId owner) internal view returns (InventoryData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = EntityId.unwrap(owner);
 
-    unchecked {
-      bytes memory _encoded = abi.encodePacked((_element));
-      StoreSwitch.spliceDynamicData(_tableId, _keyTuple, 0, uint40(_index * 2), uint40(_encoded.length), _encoded);
-    }
+    (bytes memory _staticData, EncodedLengths _encodedLengths, bytes memory _dynamicData) = StoreSwitch.getRecord(
+      _tableId,
+      _keyTuple,
+      _fieldLayout
+    );
+    return decode(_staticData, _encodedLengths, _dynamicData);
   }
 
   /**
-   * @notice Update an element of occupiedSlots at `_index`.
+   * @notice Get the full data.
    */
-  function _update(EntityId owner, uint256 _index, uint16 _element) internal {
+  function _get(EntityId owner) internal view returns (InventoryData memory _table) {
     bytes32[] memory _keyTuple = new bytes32[](1);
     _keyTuple[0] = EntityId.unwrap(owner);
 
+    (bytes memory _staticData, EncodedLengths _encodedLengths, bytes memory _dynamicData) = StoreCore.getRecord(
+      _tableId,
+      _keyTuple,
+      _fieldLayout
+    );
+    return decode(_staticData, _encodedLengths, _dynamicData);
+  }
+
+  /**
+   * @notice Set the full data using individual values.
+   */
+  function set(EntityId owner, uint16 nextSlot, uint16[] memory occupiedSlots) internal {
+    bytes memory _staticData = encodeStatic(nextSlot);
+
+    EncodedLengths _encodedLengths = encodeLengths(occupiedSlots);
+    bytes memory _dynamicData = encodeDynamic(occupiedSlots);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = EntityId.unwrap(owner);
+
+    StoreSwitch.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData);
+  }
+
+  /**
+   * @notice Set the full data using individual values.
+   */
+  function _set(EntityId owner, uint16 nextSlot, uint16[] memory occupiedSlots) internal {
+    bytes memory _staticData = encodeStatic(nextSlot);
+
+    EncodedLengths _encodedLengths = encodeLengths(occupiedSlots);
+    bytes memory _dynamicData = encodeDynamic(occupiedSlots);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = EntityId.unwrap(owner);
+
+    StoreCore.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData, _fieldLayout);
+  }
+
+  /**
+   * @notice Set the full data using the data struct.
+   */
+  function set(EntityId owner, InventoryData memory _table) internal {
+    bytes memory _staticData = encodeStatic(_table.nextSlot);
+
+    EncodedLengths _encodedLengths = encodeLengths(_table.occupiedSlots);
+    bytes memory _dynamicData = encodeDynamic(_table.occupiedSlots);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = EntityId.unwrap(owner);
+
+    StoreSwitch.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData);
+  }
+
+  /**
+   * @notice Set the full data using the data struct.
+   */
+  function _set(EntityId owner, InventoryData memory _table) internal {
+    bytes memory _staticData = encodeStatic(_table.nextSlot);
+
+    EncodedLengths _encodedLengths = encodeLengths(_table.occupiedSlots);
+    bytes memory _dynamicData = encodeDynamic(_table.occupiedSlots);
+
+    bytes32[] memory _keyTuple = new bytes32[](1);
+    _keyTuple[0] = EntityId.unwrap(owner);
+
+    StoreCore.setRecord(_tableId, _keyTuple, _staticData, _encodedLengths, _dynamicData, _fieldLayout);
+  }
+
+  /**
+   * @notice Decode the tightly packed blob of static data using this table's field layout.
+   */
+  function decodeStatic(bytes memory _blob) internal pure returns (uint16 nextSlot) {
+    nextSlot = (uint16(Bytes.getBytes2(_blob, 0)));
+  }
+
+  /**
+   * @notice Decode the tightly packed blob of dynamic data using the encoded lengths.
+   */
+  function decodeDynamic(
+    EncodedLengths _encodedLengths,
+    bytes memory _blob
+  ) internal pure returns (uint16[] memory occupiedSlots) {
+    uint256 _start;
+    uint256 _end;
     unchecked {
-      bytes memory _encoded = abi.encodePacked((_element));
-      StoreCore.spliceDynamicData(_tableId, _keyTuple, 0, uint40(_index * 2), uint40(_encoded.length), _encoded);
+      _end = _encodedLengths.atIndex(0);
     }
+    occupiedSlots = (SliceLib.getSubslice(_blob, _start, _end).decodeArray_uint16());
+  }
+
+  /**
+   * @notice Decode the tightly packed blobs using this table's field layout.
+   * @param _staticData Tightly packed static fields.
+   * @param _encodedLengths Encoded lengths of dynamic fields.
+   * @param _dynamicData Tightly packed dynamic fields.
+   */
+  function decode(
+    bytes memory _staticData,
+    EncodedLengths _encodedLengths,
+    bytes memory _dynamicData
+  ) internal pure returns (InventoryData memory _table) {
+    (_table.nextSlot) = decodeStatic(_staticData);
+
+    (_table.occupiedSlots) = decodeDynamic(_encodedLengths, _dynamicData);
   }
 
   /**
@@ -405,6 +419,14 @@ library Inventory {
     _keyTuple[0] = EntityId.unwrap(owner);
 
     StoreCore.deleteRecord(_tableId, _keyTuple, _fieldLayout);
+  }
+
+  /**
+   * @notice Tightly pack static (fixed length) data using this table's schema.
+   * @return The static data, encoded into a sequence of bytes.
+   */
+  function encodeStatic(uint16 nextSlot) internal pure returns (bytes memory) {
+    return abi.encodePacked(nextSlot);
   }
 
   /**
@@ -432,8 +454,12 @@ library Inventory {
    * @return The lengths of the dynamic fields (packed into a single bytes32 value).
    * @return The dynamic (variable length) data, encoded into a sequence of bytes.
    */
-  function encode(uint16[] memory occupiedSlots) internal pure returns (bytes memory, EncodedLengths, bytes memory) {
-    bytes memory _staticData;
+  function encode(
+    uint16 nextSlot,
+    uint16[] memory occupiedSlots
+  ) internal pure returns (bytes memory, EncodedLengths, bytes memory) {
+    bytes memory _staticData = encodeStatic(nextSlot);
+
     EncodedLengths _encodedLengths = encodeLengths(occupiedSlots);
     bytes memory _dynamicData = encodeDynamic(occupiedSlots);
 

--- a/packages/world/src/systems/BuildSystem.sol
+++ b/packages/world/src/systems/BuildSystem.sol
@@ -109,7 +109,7 @@ library BuildLib {
   function _addBlock(ObjectType buildType, Vec3 coord) internal returns (EntityId) {
     (EntityId terrain, ObjectType terrainObjectType) = getOrCreateEntityAt(coord);
     require(terrainObjectType == ObjectTypes.Air, "Cannot build on a non-air block");
-    require(Inventory._length(terrain) == 0, "Cannot build where there are dropped objects");
+    require(Inventory._lengthOccupiedSlots(terrain) == 0, "Cannot build where there are dropped objects");
     if (!buildType.isPassThrough()) {
       require(!getMovableEntityAt(coord).exists(), "Cannot build on a movable entity");
     }

--- a/packages/world/src/systems/NatureSystem.sol
+++ b/packages/world/src/systems/NatureSystem.sol
@@ -60,7 +60,7 @@ contract NatureSystem is System {
     EntityId entityId = ReversePosition._get(resourceCoord);
     ObjectType objectType = EntityObjectType._get(entityId);
     require(objectType == ObjectTypes.Air, "Resource coordinate is not air");
-    require(Inventory._length(entityId) == 0, "Cannot respawn where there are dropped objects");
+    require(Inventory._lengthOccupiedSlots(entityId) == 0, "Cannot respawn where there are dropped objects");
 
     // Remove from collected resource array
     if (resourceIdx < collected) {

--- a/packages/world/src/utils/InventoryUtils.sol
+++ b/packages/world/src/utils/InventoryUtils.sol
@@ -106,8 +106,6 @@ library InventoryUtils {
     InventorySlot._setAmount(owner, slot, 1);
 
     _addToTypeSlots(owner, objectType, slot);
-
-    return slot;
   }
 
   function addEntityToSlot(EntityId owner, EntityId entityId, uint16 slot) internal {

--- a/packages/world/test/Bed.t.sol
+++ b/packages/world/test/Bed.t.sol
@@ -419,8 +419,8 @@ contract BedTest is DustTest {
     assertInventoryHasObject(aliceEntityId, ObjectTypes.IronPick, 1);
     assertInventoryHasObject(bedEntityId, ObjectTypes.Grass, 0);
     assertInventoryHasObject(bedEntityId, ObjectTypes.IronPick, 0);
-    assertEq(Inventory.length(aliceEntityId), 2, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(bedEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 2, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(bedEntityId), 0, "Wrong number of occupied inventory slots");
 
     vm.prank(alice);
     world.sleep(aliceEntityId, bedEntityId, "");
@@ -429,8 +429,8 @@ contract BedTest is DustTest {
     assertInventoryHasObject(aliceEntityId, ObjectTypes.IronPick, 1);
     assertInventoryHasObject(bedEntityId, ObjectTypes.Grass, 0);
     assertInventoryHasObject(bedEntityId, ObjectTypes.IronPick, 0);
-    assertEq(Inventory.length(aliceEntityId), 2, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(bedEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 2, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(bedEntityId), 0, "Wrong number of occupied inventory slots");
 
     uint128 timeDelta = 1000 seconds;
     vm.warp(vm.getBlockTimestamp() + timeDelta);
@@ -443,8 +443,8 @@ contract BedTest is DustTest {
     assertInventoryHasObject(aliceEntityId, ObjectTypes.IronPick, 1);
     assertInventoryHasObject(bedEntityId, ObjectTypes.Grass, 0);
     assertInventoryHasObject(bedEntityId, ObjectTypes.IronPick, 0);
-    assertEq(Inventory.length(aliceEntityId), 2, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(bedEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 2, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(bedEntityId), 0, "Wrong number of occupied inventory slots");
 
     EnergyData memory ffEnergyData = Energy.get(forcefieldEntityId);
     assertEq(
@@ -464,8 +464,8 @@ contract BedTest is DustTest {
     assertInventoryHasObject(aliceEntityId, ObjectTypes.IronPick, 1);
     assertInventoryHasObject(bedEntityId, ObjectTypes.Grass, 0);
     assertInventoryHasObject(bedEntityId, ObjectTypes.IronPick, 0);
-    assertEq(Inventory.length(aliceEntityId), 2, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(bedEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 2, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(bedEntityId), 0, "Wrong number of occupied inventory slots");
 
     BedPlayerData memory bedPlayerData = BedPlayer.get(bedEntityId);
     assertEq(bedPlayerData.playerEntityId.unwrap(), aliceEntityId.unwrap(), "Bed's player entity is not alice");

--- a/packages/world/test/Craft.t.sol
+++ b/packages/world/test/Craft.t.sol
@@ -492,7 +492,7 @@ contract CraftTest is DustTest {
       aliceEntityId, ObjectTypes.OakLog, ObjectTypes.Player.getMaxInventorySlots() * ObjectTypes.OakLog.getStackable()
     );
     assertEq(
-      Inventory.length(aliceEntityId),
+      Inventory.lengthOccupiedSlots(aliceEntityId),
       ObjectTypes.Player.getMaxInventorySlots(),
       "Wrong number of occupied inventory slots"
     );

--- a/packages/world/test/DustTest.sol
+++ b/packages/world/test/DustTest.sol
@@ -308,10 +308,10 @@ abstract contract DustTest is MudTest, GasReporter, DustAssertions {
 
   // Helper function to find the inventory slot with a specific object type
   function findInventorySlotWithObjectType(EntityId entityId, ObjectType objectType) internal view returns (uint8) {
-    uint256 numSlots = Inventory.length(entityId);
+    uint256 numSlots = Inventory.lengthOccupiedSlots(entityId);
     for (uint8 i = 0; i < numSlots; i++) {
       // Assuming 36 inventory slots
-      ObjectType slotObjectType = InventorySlot.getObjectType(entityId, Inventory.getItem(entityId, i));
+      ObjectType slotObjectType = InventorySlot.getObjectType(entityId, Inventory.getItemOccupiedSlots(entityId, i));
       if (slotObjectType == objectType) {
         return i;
       }

--- a/packages/world/test/Inventory.t.sol
+++ b/packages/world/test/Inventory.t.sol
@@ -59,8 +59,8 @@ contract InventoryTest is DustTest {
     assertTrue(airEntityId.exists(), "Drop entity does not exist");
     assertInventoryHasObject(aliceEntityId, transferObjectType, 0);
     assertInventoryHasObject(airEntityId, transferObjectType, numToTransfer);
-    assertEq(Inventory.length(aliceEntityId), 0, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(airEntityId), 1, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(airEntityId), 1, "Wrong number of occupied inventory slots");
   }
 
   function testDropNonTerrain() public {
@@ -85,8 +85,8 @@ contract InventoryTest is DustTest {
 
     assertInventoryHasObject(aliceEntityId, transferObjectType, 0);
     assertInventoryHasObject(airEntityId, transferObjectType, numToTransfer);
-    assertEq(Inventory.length(aliceEntityId), 0, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(airEntityId), 1, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(airEntityId), 1, "Wrong number of occupied inventory slots");
   }
 
   function testDropToolTerrain() public {
@@ -112,8 +112,8 @@ contract InventoryTest is DustTest {
     assertTrue(airEntityId.exists(), "Drop entity does not exist");
     assertInventoryHasTool(aliceEntityId, toolEntityId, 0);
     assertInventoryHasTool(airEntityId, toolEntityId, 1);
-    assertEq(Inventory.length(aliceEntityId), 0, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(airEntityId), 1, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(airEntityId), 1, "Wrong number of occupied inventory slots");
   }
 
   function testDropToolNonTerrain() public {
@@ -137,8 +137,8 @@ contract InventoryTest is DustTest {
 
     assertInventoryHasTool(aliceEntityId, toolEntityId, 0);
     assertInventoryHasTool(airEntityId, toolEntityId, 1);
-    assertEq(Inventory.length(aliceEntityId), 0, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(airEntityId), 1, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(airEntityId), 1, "Wrong number of occupied inventory slots");
   }
 
   function testDropNonAirButPassable() public {
@@ -161,8 +161,8 @@ contract InventoryTest is DustTest {
 
     assertInventoryHasObject(aliceEntityId, transferObjectType, 0);
     assertInventoryHasObject(airEntityId, transferObjectType, numToTransfer);
-    assertEq(Inventory.length(aliceEntityId), 0, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(airEntityId), 1, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(airEntityId), 1, "Wrong number of occupied inventory slots");
   }
 
   function testPickup() public {
@@ -186,8 +186,8 @@ contract InventoryTest is DustTest {
 
     assertInventoryHasObject(aliceEntityId, transferObjectType, numToPickup);
     assertInventoryHasObject(airEntityId, transferObjectType, 0);
-    assertEq(Inventory.length(aliceEntityId), 1, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(airEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 1, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(airEntityId), 0, "Wrong number of occupied inventory slots");
   }
 
   function testPickupTool() public {
@@ -210,8 +210,8 @@ contract InventoryTest is DustTest {
 
     assertInventoryHasTool(aliceEntityId, toolEntityId, 1);
     assertInventoryHasTool(airEntityId, toolEntityId, 0);
-    assertEq(Inventory.length(aliceEntityId), 1, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(airEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 1, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(airEntityId), 0, "Wrong number of occupied inventory slots");
   }
 
   function testPickupMultiple() public {
@@ -241,8 +241,8 @@ contract InventoryTest is DustTest {
     assertInventoryHasObject(aliceEntityId, objectObjectType, numToPickup);
     assertInventoryHasObject(airEntityId, objectObjectType, 0);
     assertInventoryHasTool(aliceEntityId, toolEntityId, 1);
-    assertEq(Inventory.length(aliceEntityId), 2, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(airEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 2, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(airEntityId), 0, "Wrong number of occupied inventory slots");
   }
 
   function testPickupAll() public {
@@ -272,8 +272,8 @@ contract InventoryTest is DustTest {
     assertInventoryHasTool(airEntityId, toolEntityId1, 0);
     assertInventoryHasTool(aliceEntityId, toolEntityId2, 1);
     assertInventoryHasTool(airEntityId, toolEntityId2, 0);
-    assertEq(Inventory.length(aliceEntityId), 3, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(airEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 3, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(airEntityId), 0, "Wrong number of occupied inventory slots");
   }
 
   function testPickupMinedChestDrops() public {
@@ -301,8 +301,8 @@ contract InventoryTest is DustTest {
 
     assertInventoryHasObject(aliceEntityId, transferObjectType, numToPickup);
     assertInventoryHasObject(airEntityId, transferObjectType, 0);
-    assertEq(Inventory.length(aliceEntityId), 2, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(airEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 2, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(airEntityId), 0, "Wrong number of occupied inventory slots");
   }
 
   function testPickupFromNonAirButPassable() public {
@@ -324,8 +324,8 @@ contract InventoryTest is DustTest {
 
     assertInventoryHasObject(aliceEntityId, transferObjectType, numToPickup);
     assertInventoryHasObject(airEntityId, transferObjectType, 0);
-    assertEq(Inventory.length(aliceEntityId), 1, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(airEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 1, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(airEntityId), 0, "Wrong number of occupied inventory slots");
   }
 
   function testPickupFailsIfInventoryFull() public {
@@ -342,7 +342,7 @@ contract InventoryTest is DustTest {
       aliceEntityId, transferObjectType, ObjectTypes.Player.getMaxInventorySlots() * transferObjectType.getStackable()
     );
     assertEq(
-      Inventory.length(aliceEntityId),
+      Inventory.lengthOccupiedSlots(aliceEntityId),
       ObjectTypes.Player.getMaxInventorySlots(),
       "Wrong number of occupied inventory slots"
     );

--- a/packages/world/test/InventoryUtils.t.sol
+++ b/packages/world/test/InventoryUtils.t.sol
@@ -10,6 +10,7 @@ import { Inventory } from "../src/codegen/tables/Inventory.sol";
 
 import { InventorySlot, InventorySlotData } from "../src/codegen/tables/InventorySlot.sol";
 import { InventoryTypeSlots } from "../src/codegen/tables/InventoryTypeSlots.sol";
+import { Mass } from "../src/codegen/tables/Mass.sol";
 
 import { SlotTransfer, TestInventoryUtils } from "./utils/TestUtils.sol";
 
@@ -38,28 +39,28 @@ contract InventoryUtilsTest is DustTest {
     TestInventoryUtils.addEntity(aliceEntity, ObjectTypes.NeptuniumAxe);
 
     // 36 as forcefields and buckets use a single slot each
-    assertEq(Inventory.length(aliceEntity), 36);
-    assertEq(Inventory.length(bobEntity), 0);
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntity), 36);
+    assertEq(Inventory.lengthOccupiedSlots(bobEntity), 0);
 
     TestInventoryUtils.removeObjectFromSlot(aliceEntity, 1, 1);
 
-    assertEq(Inventory.length(aliceEntity), 35);
-    assertEq(Inventory.length(bobEntity), 0);
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntity), 35);
+    assertEq(Inventory.lengthOccupiedSlots(bobEntity), 0);
 
     TestInventoryUtils.transferAll(aliceEntity, bobEntity);
 
-    assertEq(Inventory.length(aliceEntity), 0);
-    assertEq(Inventory.length(bobEntity), 35);
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntity), 0);
+    assertEq(Inventory.lengthOccupiedSlots(bobEntity), 35);
 
     TestInventoryUtils.transferAll(bobEntity, aliceEntity);
 
-    assertEq(Inventory.length(aliceEntity), 35);
-    assertEq(Inventory.length(bobEntity), 0);
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntity), 35);
+    assertEq(Inventory.lengthOccupiedSlots(bobEntity), 0);
 
     TestInventoryUtils.transferAll(aliceEntity, bobEntity);
 
-    assertEq(Inventory.length(aliceEntity), 0);
-    assertEq(Inventory.length(bobEntity), 35);
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntity), 0);
+    assertEq(Inventory.lengthOccupiedSlots(bobEntity), 35);
   }
 
   function testTransferEntityToNullSlot() public {
@@ -77,9 +78,9 @@ contract InventoryUtilsTest is DustTest {
 
     TestInventoryUtils.transfer(aliceEntity, aliceEntity, transfers);
 
-    assertEq(Inventory.length(aliceEntity), 2);
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntity), 2);
 
-    uint16[] memory slots = Inventory.get(aliceEntity);
+    uint16[] memory slots = Inventory.getOccupiedSlots(aliceEntity);
     for (uint256 i = 0; i < slots.length; i++) {
       InventorySlotData memory slotData = InventorySlot.get(aliceEntity, slots[i]);
       assertEq(i, slotData.occupiedIndex, "Wrong occupied index");
@@ -91,11 +92,11 @@ contract InventoryUtilsTest is DustTest {
 
     TestInventoryUtils.addEntity(alice, ObjectTypes.WoodenHoe); // slot 0
     TestInventoryUtils.addEntity(alice, ObjectTypes.IronPick); // slot 1
-    assertEq(Inventory.length(alice), 2, "expected two occupied slots");
+    assertEq(Inventory.lengthOccupiedSlots(alice), 2, "expected two occupied slots");
 
     TestInventoryUtils.removeEntityFromSlot(alice, 0);
     TestInventoryUtils.removeEntityFromSlot(alice, 1);
-    assertEq(Inventory.length(alice), 0, "inventory should be empty");
+    assertEq(Inventory.lengthOccupiedSlots(alice), 0, "inventory should be empty");
     assertEq(InventoryTypeSlots.length(alice, ObjectTypes.Null), 2, "expected two null slots");
 
     // Reuse the slots twice
@@ -103,7 +104,7 @@ contract InventoryUtilsTest is DustTest {
     TestInventoryUtils.addEntity(alice, ObjectTypes.NeptuniumAxe);
 
     // Occupied slots should be different
-    uint16[] memory slots = Inventory.get(alice);
+    uint16[] memory slots = Inventory.getOccupiedSlots(alice);
     assertEq(slots.length, 2, "length mismatch");
     assertNotEq(slots[0], slots[1]);
   }
@@ -113,7 +114,7 @@ contract InventoryUtilsTest is DustTest {
 
     TestInventoryUtils.addEntity(aliceEntity, ObjectTypes.WoodenHoe); // slot 0
     TestInventoryUtils.addEntity(aliceEntity, ObjectTypes.IronPick); // slot 1
-    assertEq(Inventory.length(aliceEntity), 2, "expected 2 occupied slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntity), 2, "expected 2 occupied slots");
 
     SlotTransfer[] memory transfers = new SlotTransfer[](2);
     transfers[0] = SlotTransfer({ slotFrom: 0, slotTo: 2, amount: 1 });
@@ -122,13 +123,13 @@ contract InventoryUtilsTest is DustTest {
 
     // Now the inventory holds slots 2 & 3, while slots 0 & 1 sit in Null
     // (both with the same incorrect typeIndex = 0).
-    assertEq(Inventory.length(aliceEntity), 2, "inventory should still have 2 items");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntity), 2, "inventory should still have 2 items");
 
     // Require two fresh slots, `_useEmptySlot` will be invoked twice
     TestInventoryUtils.addEntity(aliceEntity, ObjectTypes.CopperAxe);
     TestInventoryUtils.addEntity(aliceEntity, ObjectTypes.NeptuniumAxe);
 
-    uint16[] memory slots = Inventory.get(aliceEntity);
+    uint16[] memory slots = Inventory.getOccupiedSlots(aliceEntity);
     assertEq(slots.length, 4, "expected 4 occupied-slot entries");
 
     // All slots should be unique and correct
@@ -147,7 +148,7 @@ contract InventoryUtilsTest is DustTest {
     // This will use an empty slot
     TestInventoryUtils.addObject(aliceEntity, ObjectTypes.Snow, 1);
 
-    uint16[] memory slots = Inventory.get(aliceEntity);
+    uint16[] memory slots = Inventory.getOccupiedSlots(aliceEntity);
     assertEq(slots.length, 3, "expected 3 occupied-slot entries");
 
     // All slots should be unique and correct
@@ -155,5 +156,149 @@ contract InventoryUtilsTest is DustTest {
       InventorySlotData memory slotData = InventorySlot.get(aliceEntity, slots[i]);
       assertEq(i, slotData.occupiedIndex, "Wrong occupied index");
     }
+  }
+
+  function testSlotGapSequential() public {
+    (, EntityId alice) = createTestPlayer(vec3(0, 0, 0));
+
+    // jump straight to slot 10
+    TestInventoryUtils.addObjectToSlot(alice, ObjectTypes.Ice, 1, 10);
+    assertEq(Inventory.lengthOccupiedSlots(alice), 1);
+
+    TestInventoryUtils.addObject(alice, ObjectTypes.Snow, 1); // slot 0
+    TestInventoryUtils.addEntity(alice, ObjectTypes.WoodenHoe); // slot 1
+
+    uint16[] memory slots = Inventory.getOccupiedSlots(alice);
+    assertEq(slots.length, 3);
+
+    // every occupiedIndex field must match its position
+    for (uint256 i; i < slots.length; ++i) {
+      InventorySlotData memory sd = InventorySlot.get(alice, slots[i]);
+      assertEq(i, sd.occupiedIndex, "Wrong occupiedIndex");
+    }
+  }
+
+  function testSwapEntityAndObject() public {
+    (, EntityId alice) = createTestPlayer(vec3(1, 1, 1));
+
+    // slot 0 = entity, slot 1 = object
+    TestInventoryUtils.addEntity(alice, ObjectTypes.CopperAxe);
+    TestInventoryUtils.addObjectToSlot(alice, ObjectTypes.OakLog, 10, 1);
+
+    SlotTransfer[] memory transfers = new SlotTransfer[](1);
+    transfers[0] = SlotTransfer({ slotFrom: 0, slotTo: 1, amount: 1 });
+
+    TestInventoryUtils.transfer(alice, alice, transfers);
+
+    uint16[] memory slots = Inventory.getOccupiedSlots(alice);
+    assertEq(slots.length, 2);
+    // verify indexes were updated by _replaceSlot
+    for (uint256 i; i < slots.length; ++i) {
+      InventorySlotData memory sd = InventorySlot.get(alice, slots[i]);
+      assertEq(i, sd.occupiedIndex, "index mismatch after swap");
+    }
+  }
+
+  function testPartialStackAddsOneSlot() public {
+    (, EntityId alice) = createTestPlayer(vec3(2, 0, 0));
+
+    // stack size = 99, add 95 logs
+    TestInventoryUtils.addObject(alice, ObjectTypes.OakLog, 95);
+    assertEq(Inventory.lengthOccupiedSlots(alice), 1);
+
+    // add 10 more, slot 0 reaches 99, slot 1 holds 6
+    TestInventoryUtils.addObject(alice, ObjectTypes.OakLog, 10);
+    assertEq(Inventory.lengthOccupiedSlots(alice), 2);
+
+    // amounts
+    uint16 a0 = InventorySlot.getAmount(alice, 0);
+    uint16 a1 = InventorySlot.getAmount(alice, 1);
+    assertEq(a0, 99);
+    assertEq(a1, 6);
+  }
+
+  function testPartialThenFullRemoval() public {
+    (, EntityId alice) = createTestPlayer(vec3(3, 0, 0));
+
+    TestInventoryUtils.addObject(alice, ObjectTypes.Snow, 99 * 2 + 1); // stack 99, so 3 slots: 99,99,1
+    assertEq(Inventory.lengthOccupiedSlots(alice), 3);
+
+    // remove 10 from slot 0, should remain occupied with 89
+    TestInventoryUtils.removeObjectFromSlot(alice, 0, 10);
+    assertEq(InventorySlot.getAmount(alice, 0), 89);
+    assertEq(Inventory.lengthOccupiedSlots(alice), 3);
+
+    // now remove the remaining 89, slot recycled, only two occupied left
+    TestInventoryUtils.removeObjectFromSlot(alice, 0, 89);
+    assertEq(Inventory.lengthOccupiedSlots(alice), 2);
+
+    // Null list should contain exactly one new entry
+    assertEq(InventoryTypeSlots.length(alice, ObjectTypes.Null), 1);
+  }
+
+  function testUseEmptySlotAfterGap() public {
+    (, EntityId alice) = createTestPlayer(vec3(0, 0, 0));
+
+    // jump straight to slot 10, leaving 0-9 untouched
+    TestInventoryUtils.addObjectToSlot(alice, ObjectTypes.Ice, 1, 10);
+
+    // first fresh allocation must reuse slot 9 (we pop from the end of null type slots)
+    TestInventoryUtils.addObject(alice, ObjectTypes.Snow, 1);
+    uint16[] memory occ = Inventory.getOccupiedSlots(alice);
+
+    assertEq(occ.length, 2, "two occupied slots expected");
+    assertTrue(occ[0] != occ[1], "slots must differ");
+  }
+
+  function testRemoveAcrossSlots() public {
+    (, EntityId alice) = createTestPlayer(vec3(0, 0, 0));
+
+    // 150 OakLog, slots: 99 + 51
+    TestInventoryUtils.addObject(alice, ObjectTypes.OakLog, 150);
+    TestInventoryUtils.removeObject(alice, ObjectTypes.OakLog, 120); // leaves 30
+
+    uint16[] memory occ = Inventory.getOccupiedSlots(alice);
+    assertEq(occ.length, 1, "only one slot should remain");
+    assertEq(InventorySlot.getAmount(alice, occ[0]), 30, "wrong remaining amount");
+  }
+
+  function testSwapDifferentTypesBetweenEntities() public {
+    (, EntityId alice) = createTestPlayer(vec3(0, 0, 0));
+    (, EntityId bob) = createTestPlayer(vec3(1, 0, 0));
+
+    TestInventoryUtils.addObject(alice, ObjectTypes.OakLog, 10);
+    TestInventoryUtils.addEntity(alice, ObjectTypes.CopperAxe);
+
+    TestInventoryUtils.addObject(bob, ObjectTypes.Sand, 20);
+
+    SlotTransfer[] memory transfers = new SlotTransfer[](1);
+    transfers[0] = SlotTransfer({ slotFrom: 0, slotTo: 0, amount: 10 }); // swap OakLog <-> Sand
+    TestInventoryUtils.transfer(alice, bob, transfers);
+
+    // indices must be consistent
+    uint16[] memory aliceSlots = Inventory.getOccupiedSlots(alice);
+    for (uint256 i; i < aliceSlots.length; ++i) {
+      InventorySlotData memory d = InventorySlot.get(alice, aliceSlots[i]);
+      assertEq(i, d.occupiedIndex, "alice index wrong");
+    }
+    uint16[] memory bobSlots = Inventory.getOccupiedSlots(bob);
+    for (uint256 i; i < bobSlots.length; ++i) {
+      InventorySlotData memory d = InventorySlot.get(bob, bobSlots[i]);
+      assertEq(i, d.occupiedIndex, "bob index wrong");
+    }
+  }
+
+  function testToolBreakRemovesSlot() public {
+    (, EntityId alice) = createTestPlayer(vec3(0, 0, 0));
+
+    // manually set mass low so one use breaks it
+    EntityId entityId = TestInventoryUtils.addEntity(alice, ObjectTypes.WoodenPick);
+    Mass.setMass(entityId, 1);
+
+    // Use tool with mass reduction ≥ 1
+    TestInventoryUtils.useTool(alice, vec3(0, 0, 0), 0, 5);
+
+    assertEq(Inventory.lengthOccupiedSlots(alice), 0, "slot not recycled");
+    assertEq(InventoryTypeSlots.length(alice, ObjectTypes.Null), 1, "slot not in Null list");
   }
 }

--- a/packages/world/test/Mine.t.sol
+++ b/packages/world/test/Mine.t.sol
@@ -164,7 +164,7 @@ contract MineTest is DustTest {
     assertEq(EntityObjectType.get(mineEntityId), ObjectTypes.Air, "Entity should be air");
     assertEq(Mass.getMass(mineEntityId), 0, "Mine entity mass is not 0");
     assertInventoryHasObject(aliceEntityId, ObjectTypes.UnrevealedOre, 0);
-    assertEq(Inventory.length(aliceEntityId), 1, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 1, "Wrong number of occupied inventory slots");
     oreAmounts = inventoryGetOreAmounts(aliceEntityId);
     assertEq(oreAmounts.length, 1, "No ores in inventory");
     assertEq(oreAmounts[0].amount, 1, "Did not get exactly one ore");
@@ -450,7 +450,7 @@ contract MineTest is DustTest {
       aliceEntityId, mineObjectType, ObjectTypes.Player.getMaxInventorySlots() * mineObjectType.getStackable()
     );
     assertEq(
-      Inventory.length(aliceEntityId),
+      Inventory.lengthOccupiedSlots(aliceEntityId),
       ObjectTypes.Player.getMaxInventorySlots(),
       "Wrong number of occupied inventory slots"
     );

--- a/packages/world/test/Move.t.sol
+++ b/packages/world/test/Move.t.sol
@@ -551,7 +551,7 @@ contract MoveTest is DustTest {
     assertInventoryHasObject(entityAtDeathLocation, ObjectTypes.IronOre, 5);
 
     // Player's inventory should be empty
-    assertEq(Inventory.length(aliceEntityId), 0, "Inventory not empty");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 0, "Inventory not empty");
   }
 
   function testMoveHorizontalPathFatal() public {
@@ -600,7 +600,7 @@ contract MoveTest is DustTest {
     assertInventoryHasObject(entityAtDeathLocation, ObjectTypes.Diamond, 3);
 
     // Player's inventory should be empty
-    assertEq(Inventory.length(aliceEntityId), 0, "Player inventory not empty");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 0, "Player inventory not empty");
   }
 
   function testMoveFailsIfNoPlayer() public {

--- a/packages/world/test/Transfer.t.sol
+++ b/packages/world/test/Transfer.t.sol
@@ -140,8 +140,8 @@ contract TransferTest is DustTest {
 
     assertInventoryHasObject(aliceEntityId, transferObjectType, 0);
     assertInventoryHasObject(chestEntityId, transferObjectType, numToTransfer);
-    assertEq(Inventory.length(aliceEntityId), 0, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(chestEntityId), 1, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(chestEntityId), 1, "Wrong number of occupied inventory slots");
   }
 
   function testTransferToolToChest() public {
@@ -164,8 +164,8 @@ contract TransferTest is DustTest {
 
     assertInventoryHasTool(chestEntityId, toolEntityId, 1);
     assertInventoryHasTool(aliceEntityId, toolEntityId, 0);
-    assertEq(Inventory.length(chestEntityId), 1, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(aliceEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(chestEntityId), 1, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 0, "Wrong number of occupied inventory slots");
   }
 
   function testTransferFromChest() public {
@@ -189,8 +189,8 @@ contract TransferTest is DustTest {
 
     assertInventoryHasObject(aliceEntityId, transferObjectType, numToTransfer);
     assertInventoryHasObject(chestEntityId, transferObjectType, 0);
-    assertEq(Inventory.length(aliceEntityId), 1, "Inventory not set");
-    assertEq(Inventory.length(chestEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 1, "Inventory not set");
+    assertEq(Inventory.lengthOccupiedSlots(chestEntityId), 0, "Wrong number of occupied inventory slots");
   }
 
   function testTransferToolFromChest() public {
@@ -218,8 +218,8 @@ contract TransferTest is DustTest {
     assertInventoryHasTool(aliceEntityId, toolEntityId2, 1);
     assertInventoryHasTool(chestEntityId, toolEntityId1, 0);
     assertInventoryHasTool(chestEntityId, toolEntityId2, 0);
-    assertEq(Inventory.length(aliceEntityId), 2, "Wrong number of occupied inventory slots");
-    assertEq(Inventory.length(chestEntityId), 0, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 2, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(chestEntityId), 0, "Wrong number of occupied inventory slots");
   }
 
   function testTransferToChestFailsIfChestFull() public {
@@ -232,7 +232,7 @@ contract TransferTest is DustTest {
     TestInventoryUtils.addObject(
       chestEntityId, transferObjectType, transferObjectType.getStackable() * maxChestInventorySlots
     );
-    assertEq(Inventory.length(chestEntityId), maxChestInventorySlots, "Inventory slots is not max");
+    assertEq(Inventory.lengthOccupiedSlots(chestEntityId), maxChestInventorySlots, "Inventory slots is not max");
 
     TestInventoryUtils.addObject(aliceEntityId, transferObjectType, 1);
     assertInventoryHasObject(aliceEntityId, transferObjectType, 1);
@@ -255,7 +255,7 @@ contract TransferTest is DustTest {
     TestInventoryUtils.addObject(
       aliceEntityId, transferObjectType, transferObjectType.getStackable() * maxPlayerInventorySlots
     );
-    assertEq(Inventory.length(aliceEntityId), maxPlayerInventorySlots, "Inventory slots is not max");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), maxPlayerInventorySlots, "Inventory slots is not max");
 
     TestInventoryUtils.addObject(chestEntityId, transferObjectType, 1);
     assertInventoryHasObject(chestEntityId, transferObjectType, 1);
@@ -535,7 +535,7 @@ contract TransferTest is DustTest {
 
     assertInventoryHasObjectInSlot(aliceEntityId, fromType, fromAmount, 0);
     assertInventoryHasObjectInSlot(aliceEntityId, toType, toAmount, 1);
-    assertEq(Inventory.length(aliceEntityId), 2, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 2, "Wrong number of occupied inventory slots");
 
     SlotTransfer[] memory slotsToTransfer = new SlotTransfer[](1);
     slotsToTransfer[0] = SlotTransfer({ slotFrom: 0, slotTo: 1, amount: fromAmount });
@@ -547,7 +547,7 @@ contract TransferTest is DustTest {
 
     assertInventoryHasObjectInSlot(aliceEntityId, fromType, fromAmount, 1);
     assertInventoryHasObjectInSlot(aliceEntityId, toType, toAmount, 0);
-    assertEq(Inventory.length(aliceEntityId), 2, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 2, "Wrong number of occupied inventory slots");
   }
 
   function testSwapEntityAndObjectSlots() public {
@@ -562,7 +562,7 @@ contract TransferTest is DustTest {
 
     assertInventoryHasObjectInSlot(aliceEntityId, fromType, fromAmount, 0);
     assertInventoryHasObjectInSlot(aliceEntityId, toType, 1, 1);
-    assertEq(Inventory.length(aliceEntityId), 2, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 2, "Wrong number of occupied inventory slots");
 
     // Transfer all grass
     SlotTransfer[] memory slotsToTransfer = new SlotTransfer[](1);
@@ -575,7 +575,7 @@ contract TransferTest is DustTest {
 
     assertInventoryHasObjectInSlot(aliceEntityId, fromType, fromAmount, 1);
     assertInventoryHasObjectInSlot(aliceEntityId, toType, 1, 0);
-    assertEq(Inventory.length(aliceEntityId), 2, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 2, "Wrong number of occupied inventory slots");
   }
 
   function testSwapEntitySlots() public {
@@ -589,7 +589,7 @@ contract TransferTest is DustTest {
 
     assertInventoryHasObjectInSlot(aliceEntityId, fromType, 1, 0);
     assertInventoryHasObjectInSlot(aliceEntityId, toType, 1, 1);
-    assertEq(Inventory.length(aliceEntityId), 2, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 2, "Wrong number of occupied inventory slots");
 
     SlotTransfer[] memory slotsToTransfer = new SlotTransfer[](1);
     slotsToTransfer[0] = SlotTransfer({ slotFrom: 0, slotTo: 1, amount: 1 });
@@ -601,7 +601,7 @@ contract TransferTest is DustTest {
 
     assertInventoryHasObjectInSlot(aliceEntityId, fromType, 1, 1);
     assertInventoryHasObjectInSlot(aliceEntityId, toType, 1, 0);
-    assertEq(Inventory.length(aliceEntityId), 2, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 2, "Wrong number of occupied inventory slots");
   }
 
   function testSelfTransferEntityToNullSlot() public {
@@ -611,7 +611,7 @@ contract TransferTest is DustTest {
     TestInventoryUtils.addEntity(aliceEntityId, fromType);
 
     assertInventoryHasObjectInSlot(aliceEntityId, fromType, 1, 0);
-    assertEq(Inventory.length(aliceEntityId), 1, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 1, "Wrong number of occupied inventory slots");
 
     SlotTransfer[] memory slotsToTransfer = new SlotTransfer[](1);
     slotsToTransfer[0] = SlotTransfer({ slotFrom: 0, slotTo: 1, amount: 1 });
@@ -622,7 +622,7 @@ contract TransferTest is DustTest {
     endGasReport();
 
     assertInventoryHasObjectInSlot(aliceEntityId, fromType, 1, 1);
-    assertEq(Inventory.length(aliceEntityId), 1, "Wrong number of occupied inventory slots");
+    assertEq(Inventory.lengthOccupiedSlots(aliceEntityId), 1, "Wrong number of occupied inventory slots");
   }
 
   function testTransferWithinChestInventory() public {

--- a/packages/world/test/utils/TestUtils.sol
+++ b/packages/world/test/utils/TestUtils.sol
@@ -109,6 +109,10 @@ library TestInventoryUtils {
     InventoryUtils.removeObjectFromSlot(ownerEntityId, slot, numObjectsToRemove);
   }
 
+  function useTool(EntityId owner, Vec3 ownerCoord, uint16 slot, uint128 useMassMax) public asWorld {
+    InventoryUtils.useTool(owner, ownerCoord, slot, useMassMax);
+  }
+
   function getEntitySlot(EntityId owner, EntityId entityId) public asWorld returns (uint16) {
     ObjectType objectType = EntityObjectType._get(entityId);
     uint16[] memory slots = InventoryTypeSlots._get(owner, objectType);


### PR DESCRIPTION
tldr:
- Keep track of next non-tracked slot
- If objects are added, it first tries to take from tracked null slots (same as before). If null slots are empty, use the next non-tracked slot
- If an object/entity is added to a specific slot that is > next non-tracked slot, it loops through non-tracked slots and adds them to null slots
- So the only O(n) operation is when adding an object to a slot that leaves a gap between next non-tracked slot and slot (where n = slot - next <= maxSlots). And as there is no point to add stuff directly to air inventory slots, this is fine