### PR TITLE
support postdeploy kms

### DIFF
--- a/packages/programs/script/PostDeploy.s.sol
+++ b/packages/programs/script/PostDeploy.s.sol
@@ -20,6 +20,34 @@ import { SpawnTileProgram } from "../src/programs/SpawnTileProgram.sol";
 bytes14 constant DEFAULT_NAMESPACE = "dfprograms_1";
 
 contract PostDeploy is Script {
+  function run(address worldAddress) external {
+    // Specify a store so that you can use tables directly in PostDeploy
+    StoreSwitch.setStoreAddress(worldAddress);
+
+    // Load the private key from the `PRIVATE_KEY` environment variable (in .env)
+    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+    // Start broadcasting transactions from the deployer account
+    vm.startBroadcast(deployerPrivateKey);
+
+    postDeploy(worldAddress);
+
+    vm.stopBroadcast();
+  }
+
+  // TODO: remove this once MUD supports PostDeploy with KMS: https://github.com/latticexyz/mud/issues/3716
+  function run(address worldAddress, address deployerAddress) external {
+    // Specify a store so that you can use tables directly in PostDeploy
+    StoreSwitch.setStoreAddress(worldAddress);
+
+    // Start broadcasting transactions from the deployer account
+    vm.startBroadcast(deployerAddress);
+
+    postDeploy(worldAddress);
+
+    vm.stopBroadcast();
+  }
+
   function postDeploy(address worldAddress) internal {
     IWorld world = IWorld(worldAddress);
 
@@ -50,33 +78,5 @@ contract PostDeploy is Script {
       SpawnTileProgram spawnTileProgram = new SpawnTileProgram(world);
       world.registerSystem(spawnTileProgramId, spawnTileProgram, false);
     }
-  }
-
-  function run(address worldAddress) external {
-    // Specify a store so that you can use tables directly in PostDeploy
-    StoreSwitch.setStoreAddress(worldAddress);
-
-    // Load the private key from the `PRIVATE_KEY` environment variable (in .env)
-    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-
-    // Start broadcasting transactions from the deployer account
-    vm.startBroadcast(deployerPrivateKey);
-
-    postDeploy(worldAddress);
-
-    vm.stopBroadcast();
-  }
-
-  // TODO: remove this once MUD supports PostDeploy with KMS: https://github.com/latticexyz/mud/issues/3716
-  function run(address worldAddress, address deployerAddress) external {
-    // Specify a store so that you can use tables directly in PostDeploy
-    StoreSwitch.setStoreAddress(worldAddress);
-
-    // Start broadcasting transactions from the deployer account
-    vm.startBroadcast(deployerAddress);
-
-    postDeploy(worldAddress);
-
-    vm.stopBroadcast();
   }
 }

--- a/packages/programs/script/PostDeploy.s.sol
+++ b/packages/programs/script/PostDeploy.s.sol
@@ -20,16 +20,7 @@ import { SpawnTileProgram } from "../src/programs/SpawnTileProgram.sol";
 bytes14 constant DEFAULT_NAMESPACE = "dfprograms_1";
 
 contract PostDeploy is Script {
-  function run(address worldAddress) external {
-    // Specify a store so that you can use tables directly in PostDeploy
-    StoreSwitch.setStoreAddress(worldAddress);
-
-    // Load the private key from the `PRIVATE_KEY` environment variable (in .env)
-    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-
-    // Start broadcasting transactions from the deployer account
-    vm.startBroadcast(deployerPrivateKey);
-
+  function postDeploy(address worldAddress) internal {
     IWorld world = IWorld(worldAddress);
 
     // Create the programs
@@ -59,6 +50,32 @@ contract PostDeploy is Script {
       SpawnTileProgram spawnTileProgram = new SpawnTileProgram(world);
       world.registerSystem(spawnTileProgramId, spawnTileProgram, false);
     }
+  }
+
+  function run(address worldAddress) external {
+    // Specify a store so that you can use tables directly in PostDeploy
+    StoreSwitch.setStoreAddress(worldAddress);
+
+    // Load the private key from the `PRIVATE_KEY` environment variable (in .env)
+    uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+    // Start broadcasting transactions from the deployer account
+    vm.startBroadcast(deployerPrivateKey);
+
+    postDeploy(worldAddress);
+
+    vm.stopBroadcast();
+  }
+
+  // TODO: remove this once MUD supports PostDeploy with KMS: https://github.com/latticexyz/mud/issues/3716
+  function run(address worldAddress, address deployerAddress) external {
+    // Specify a store so that you can use tables directly in PostDeploy
+    StoreSwitch.setStoreAddress(worldAddress);
+
+    // Start broadcasting transactions from the deployer account
+    vm.startBroadcast(deployerAddress);
+
+    postDeploy(worldAddress);
 
     vm.stopBroadcast();
   }

--- a/packages/world/script/PostDeploy.s.sol
+++ b/packages/world/script/PostDeploy.s.sol
@@ -16,6 +16,15 @@ import { initRecipes } from "./initRecipes.sol";
 import { initTerrain } from "./initTerrain.sol";
 
 contract PostDeploy is Script {
+  function postDeploy(address worldAddress) internal {
+    RegisterSelectorHook registerSelectorHook = new RegisterSelectorHook();
+    IWorld(worldAddress).registerSystemHook(REGISTRATION_SYSTEM_ID, registerSelectorHook, BEFORE_CALL_SYSTEM);
+
+    initTerrain();
+    initObjects();
+    initRecipes();
+  }
+
   function run(address worldAddress) external {
     // Specify a store so that you can use tables directly in PostDeploy
     StoreSwitch.setStoreAddress(worldAddress);
@@ -26,12 +35,20 @@ contract PostDeploy is Script {
     // Start broadcasting transactions from the deployer account
     vm.startBroadcast(deployerPrivateKey);
 
-    RegisterSelectorHook registerSelectorHook = new RegisterSelectorHook();
-    IWorld(worldAddress).registerSystemHook(REGISTRATION_SYSTEM_ID, registerSelectorHook, BEFORE_CALL_SYSTEM);
+    postDeploy(worldAddress);
 
-    initTerrain();
-    initObjects();
-    initRecipes();
+    vm.stopBroadcast();
+  }
+
+  // TODO: remove this once MUD supports PostDeploy with KMS: https://github.com/latticexyz/mud/issues/3716
+  function run(address worldAddress, address deployerAddress) external {
+    // Specify a store so that you can use tables directly in PostDeploy
+    StoreSwitch.setStoreAddress(worldAddress);
+
+    // Start broadcasting transactions from the deployer account
+    vm.startBroadcast(deployerAddress);
+
+    postDeploy(worldAddress);
 
     vm.stopBroadcast();
   }

--- a/packages/world/script/PostDeploy.s.sol
+++ b/packages/world/script/PostDeploy.s.sol
@@ -16,15 +16,6 @@ import { initRecipes } from "./initRecipes.sol";
 import { initTerrain } from "./initTerrain.sol";
 
 contract PostDeploy is Script {
-  function postDeploy(address worldAddress) internal {
-    RegisterSelectorHook registerSelectorHook = new RegisterSelectorHook();
-    IWorld(worldAddress).registerSystemHook(REGISTRATION_SYSTEM_ID, registerSelectorHook, BEFORE_CALL_SYSTEM);
-
-    initTerrain();
-    initObjects();
-    initRecipes();
-  }
-
   function run(address worldAddress) external {
     // Specify a store so that you can use tables directly in PostDeploy
     StoreSwitch.setStoreAddress(worldAddress);
@@ -51,5 +42,14 @@ contract PostDeploy is Script {
     postDeploy(worldAddress);
 
     vm.stopBroadcast();
+  }
+
+  function postDeploy(address worldAddress) internal {
+    RegisterSelectorHook registerSelectorHook = new RegisterSelectorHook();
+    IWorld(worldAddress).registerSystemHook(REGISTRATION_SYSTEM_ID, registerSelectorHook, BEFORE_CALL_SYSTEM);
+
+    initTerrain();
+    initObjects();
+    initRecipes();
   }
 }


### PR DESCRIPTION
- add a run method to postdeploy that takes in a deployer address as this is required to run the script via KMS
- can be removed after its supported in MUD: https://github.com/latticexyz/mud/issues/3716