### PR TITLE
feat: drop on mine if further than max pickup range

### DIFF
--- a/packages/world/src/Constants.sol
+++ b/packages/world/src/Constants.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.24;
 
-uint32 constant MAX_ENTITY_INFLUENCE_HALF_WIDTH = 10;
+uint32 constant MAX_ENTITY_INFLUENCE_RADIUS = 10;
+uint32 constant MAX_PICKUP_RADIUS = 6;
 uint32 constant MAX_RESPAWN_HALF_WIDTH = 10;
 
 uint16 constant MAX_PLAYER_JUMPS = 3;

--- a/packages/world/src/systems/InventorySystem.sol
+++ b/packages/world/src/systems/InventorySystem.sol
@@ -5,6 +5,7 @@ import { System } from "@latticexyz/world/src/System.sol";
 
 import { Action } from "../codegen/common.sol";
 
+import { MAX_PICKUP_RADIUS } from "../Constants.sol";
 import { EntityId } from "../EntityId.sol";
 import { ObjectType } from "../ObjectType.sol";
 import { ObjectTypes } from "../ObjectType.sol";
@@ -30,7 +31,7 @@ contract InventorySystem is System {
 
   function pickup(EntityId caller, SlotTransfer[] memory slotTransfers, Vec3 coord) public {
     caller.activate();
-    caller.requireConnected(coord);
+    caller.requireInRange(coord, MAX_PICKUP_RADIUS);
 
     (EntityId entityId, ObjectType objectType) = EntityUtils.getBlockAt(coord);
     require(objectType.isPassThrough(), "Cannot pickup from a non-passable block");
@@ -40,7 +41,7 @@ contract InventorySystem is System {
 
   function pickupAll(EntityId caller, Vec3 coord) public {
     caller.activate();
-    caller.requireConnected(coord);
+    caller.requireInRange(coord, MAX_PICKUP_RADIUS);
 
     (EntityId entityId, ObjectType objectType) = EntityUtils.getBlockAt(coord);
     require(objectType.isPassThrough(), "Cannot pickup from a non-passable block");

--- a/packages/world/test/Bucket.t.sol
+++ b/packages/world/test/Bucket.t.sol
@@ -12,7 +12,7 @@ import { Energy, EnergyData } from "../src/codegen/tables/Energy.sol";
 import { EntityObjectType } from "../src/codegen/tables/EntityObjectType.sol";
 import { Mass } from "../src/codegen/tables/Mass.sol";
 
-import { MAX_ENTITY_INFLUENCE_HALF_WIDTH } from "../src/Constants.sol";
+import { MAX_ENTITY_INFLUENCE_RADIUS } from "../src/Constants.sol";
 import { ObjectType } from "../src/ObjectType.sol";
 
 import { ObjectTypes } from "../src/ObjectType.sol";
@@ -95,7 +95,7 @@ contract BucketTest is DustTest {
   function testFillBucketFailsIfTooFar() public {
     (address alice, EntityId aliceEntityId, Vec3 playerCoord) = setupWaterChunkWithPlayer();
 
-    Vec3 waterCoord = vec3(playerCoord.x() + int32(MAX_ENTITY_INFLUENCE_HALF_WIDTH) + 1, 0, playerCoord.z());
+    Vec3 waterCoord = vec3(playerCoord.x() + int32(MAX_ENTITY_INFLUENCE_RADIUS) + 1, 0, playerCoord.z());
 
     TestInventoryUtils.addObject(aliceEntityId, ObjectTypes.Bucket, 1);
 
@@ -133,7 +133,7 @@ contract BucketTest is DustTest {
   function testWetFarmlandFailsIfTooFar() public {
     (address alice, EntityId aliceEntityId, Vec3 playerCoord) = setupAirChunkWithPlayer();
 
-    Vec3 farmlandCoord = vec3(playerCoord.x() + int32(MAX_ENTITY_INFLUENCE_HALF_WIDTH) + 1, 0, playerCoord.z());
+    Vec3 farmlandCoord = vec3(playerCoord.x() + int32(MAX_ENTITY_INFLUENCE_RADIUS) + 1, 0, playerCoord.z());
     setObjectAtCoord(farmlandCoord, ObjectTypes.Farmland);
 
     TestInventoryUtils.addObject(aliceEntityId, ObjectTypes.WaterBucket, 1);

--- a/packages/world/test/Build.t.sol
+++ b/packages/world/test/Build.t.sol
@@ -19,7 +19,7 @@ import { DustTest } from "./DustTest.sol";
 
 import { EntityPosition, LocalEnergyPool, ReverseMovablePosition } from "../src/utils/Vec3Storage.sol";
 
-import { BUILD_ENERGY_COST, CHUNK_SIZE, MAX_ENTITY_INFLUENCE_HALF_WIDTH, MAX_FLUID_LEVEL } from "../src/Constants.sol";
+import { BUILD_ENERGY_COST, CHUNK_SIZE, MAX_ENTITY_INFLUENCE_RADIUS, MAX_FLUID_LEVEL } from "../src/Constants.sol";
 import { ObjectType } from "../src/ObjectType.sol";
 
 import { ObjectTypes } from "../src/ObjectType.sol";
@@ -376,7 +376,7 @@ contract BuildTest is DustTest {
   function testBuildFailsIfInvalidCoord() public {
     (address alice, EntityId aliceEntityId, Vec3 playerCoord) = setupAirChunkWithPlayer();
 
-    Vec3 buildCoord = playerCoord + vec3(int32(MAX_ENTITY_INFLUENCE_HALF_WIDTH) + 1, 0, 0);
+    Vec3 buildCoord = playerCoord + vec3(int32(MAX_ENTITY_INFLUENCE_RADIUS) + 1, 0, 0);
     ObjectType buildObjectType = ObjectTypes.Grass;
     TestInventoryUtils.addObject(aliceEntityId, buildObjectType, 1);
 

--- a/packages/world/test/Craft.t.sol
+++ b/packages/world/test/Craft.t.sol
@@ -22,7 +22,7 @@ import { PlayerBed } from "../src/codegen/tables/PlayerBed.sol";
 import { WorldStatus } from "../src/codegen/tables/WorldStatus.sol";
 import { DustTest } from "./DustTest.sol";
 
-import { CHUNK_SIZE, MAX_ENTITY_INFLUENCE_HALF_WIDTH } from "../src/Constants.sol";
+import { CHUNK_SIZE, MAX_ENTITY_INFLUENCE_RADIUS } from "../src/Constants.sol";
 import { ObjectType } from "../src/ObjectType.sol";
 
 import { ObjectTypes } from "../src/ObjectType.sol";
@@ -462,7 +462,7 @@ contract CraftTest is DustTest {
     vm.expectRevert("Invalid station");
     world.craftWithStation(aliceEntityId, stationEntityId, recipeId, inputs);
 
-    stationCoord = playerCoord + vec3(int32(MAX_ENTITY_INFLUENCE_HALF_WIDTH) + 1, 0, 0);
+    stationCoord = playerCoord + vec3(int32(MAX_ENTITY_INFLUENCE_RADIUS) + 1, 0, 0);
     stationEntityId = setObjectAtCoord(stationCoord, ObjectTypes.Workbench);
 
     vm.prank(alice);

--- a/packages/world/test/Farming.t.sol
+++ b/packages/world/test/Farming.t.sol
@@ -21,7 +21,7 @@ import { EntityPosition } from "../src/utils/Vec3Storage.sol";
 import {
   BUILD_ENERGY_COST,
   CHUNK_COMMIT_EXPIRY_BLOCKS,
-  MAX_ENTITY_INFLUENCE_HALF_WIDTH,
+  MAX_ENTITY_INFLUENCE_RADIUS,
   TILL_ENERGY_COST
 } from "../src/Constants.sol";
 
@@ -142,7 +142,7 @@ contract FarmingTest is DustTest {
   function testTillFailsIfTooFar() public {
     (address alice, EntityId aliceEntityId, Vec3 playerCoord) = setupAirChunkWithPlayer();
 
-    Vec3 dirtCoord = vec3(playerCoord.x() + int32(MAX_ENTITY_INFLUENCE_HALF_WIDTH) + 1, 0, playerCoord.z());
+    Vec3 dirtCoord = vec3(playerCoord.x() + int32(MAX_ENTITY_INFLUENCE_RADIUS) + 1, 0, playerCoord.z());
     setTerrainAtCoord(dirtCoord, ObjectTypes.Dirt);
 
     TestInventoryUtils.addEntity(aliceEntityId, ObjectTypes.WoodenHoe);

--- a/packages/world/test/Inventory.t.sol
+++ b/packages/world/test/Inventory.t.sol
@@ -20,7 +20,7 @@ import { TerrainLib } from "../src/systems/libraries/TerrainLib.sol";
 
 import { EntityPosition } from "../src/utils/Vec3Storage.sol";
 
-import { CHUNK_SIZE, MAX_ENTITY_INFLUENCE_HALF_WIDTH } from "../src/Constants.sol";
+import { CHUNK_SIZE, MAX_ENTITY_INFLUENCE_RADIUS } from "../src/Constants.sol";
 import { EntityId } from "../src/EntityId.sol";
 
 import { ObjectType } from "../src/ObjectType.sol";
@@ -343,7 +343,7 @@ contract InventoryTest is DustTest {
   function testPickupFailsIfInvalidCoord() public {
     (address alice, EntityId aliceEntityId, Vec3 playerCoord) = setupAirChunkWithPlayer();
 
-    Vec3 pickupCoord = playerCoord + vec3(int32(MAX_ENTITY_INFLUENCE_HALF_WIDTH) + 1, 1, 0);
+    Vec3 pickupCoord = playerCoord + vec3(int32(MAX_ENTITY_INFLUENCE_RADIUS) + 1, 1, 0);
     EntityId airEntityId = setObjectAtCoord(pickupCoord, ObjectTypes.Air);
     ObjectType transferObjectType = ObjectTypes.Grass;
     TestInventoryUtils.addObject(airEntityId, transferObjectType, 1);
@@ -361,7 +361,7 @@ contract InventoryTest is DustTest {
   function testDropFailsIfInvalidCoord() public {
     (address alice, EntityId aliceEntityId, Vec3 playerCoord) = setupAirChunkWithPlayer();
 
-    Vec3 dropCoord = playerCoord + vec3(int32(MAX_ENTITY_INFLUENCE_HALF_WIDTH) + 1, 1, 0);
+    Vec3 dropCoord = playerCoord + vec3(int32(MAX_ENTITY_INFLUENCE_RADIUS) + 1, 1, 0);
     setObjectAtCoord(dropCoord, ObjectTypes.Air);
     ObjectType transferObjectType = ObjectTypes.Grass;
     TestInventoryUtils.addObject(aliceEntityId, transferObjectType, 1);

--- a/packages/world/test/Mine.t.sol
+++ b/packages/world/test/Mine.t.sol
@@ -34,7 +34,7 @@ import {
   DEFAULT_MINE_ENERGY_COST,
   DEFAULT_WOODEN_TOOL_MULTIPLIER,
   MACHINE_ENERGY_DRAIN_RATE,
-  MAX_ENTITY_INFLUENCE_HALF_WIDTH,
+  MAX_ENTITY_INFLUENCE_RADIUS,
   MAX_FLUID_LEVEL,
   MAX_PLAYER_ENERGY,
   PLAYER_ENERGY_DRAIN_RATE,
@@ -572,7 +572,7 @@ contract MineTest is DustTest {
   function testMineFailsIfInvalidCoord() public {
     (address alice, EntityId aliceEntityId, Vec3 playerCoord) = setupAirChunkWithPlayer();
 
-    Vec3 mineCoord = playerCoord + vec3(int32(MAX_ENTITY_INFLUENCE_HALF_WIDTH) + 1, 0, 0);
+    Vec3 mineCoord = playerCoord + vec3(int32(MAX_ENTITY_INFLUENCE_RADIUS) + 1, 0, 0);
     ObjectType mineObjectType = ObjectTypes.Dirt;
     setObjectAtCoord(mineCoord, mineObjectType);
 

--- a/packages/world/test/Transfer.t.sol
+++ b/packages/world/test/Transfer.t.sol
@@ -27,7 +27,7 @@ import { ITransferSystem } from "../src/codegen/world/ITransferSystem.sol";
 import { IWorld } from "../src/codegen/world/IWorld.sol";
 import { DustTest } from "./DustTest.sol";
 
-import { CHUNK_SIZE, MAX_ENTITY_INFLUENCE_HALF_WIDTH } from "../src/Constants.sol";
+import { CHUNK_SIZE, MAX_ENTITY_INFLUENCE_RADIUS } from "../src/Constants.sol";
 import { ObjectType } from "../src/ObjectType.sol";
 
 import { ObjectTypes } from "../src/ObjectType.sol";
@@ -416,7 +416,7 @@ contract TransferTest is DustTest {
   function testTransferFailsIfTooFar() public {
     (address alice, EntityId aliceEntityId, Vec3 playerCoord) = setupAirChunkWithPlayer();
 
-    Vec3 chestCoord = playerCoord + vec3(int32(MAX_ENTITY_INFLUENCE_HALF_WIDTH) + 1, 0, 1);
+    Vec3 chestCoord = playerCoord + vec3(int32(MAX_ENTITY_INFLUENCE_RADIUS) + 1, 0, 1);
     EntityId chestEntityId = setObjectAtCoord(chestCoord, ObjectTypes.Chest);
     ObjectType transferObjectType = ObjectTypes.Grass;
     TestInventoryUtils.addObject(aliceEntityId, transferObjectType, 1);
@@ -537,7 +537,7 @@ contract TransferTest is DustTest {
 
   function testTransferBetweenChestsFailIfTooFar() public {
     Vec3 chestCoord = vec3(0, 0, 0);
-    Vec3 otherChestCoord = chestCoord + vec3(int32(MAX_ENTITY_INFLUENCE_HALF_WIDTH) + 1, 0, 0);
+    Vec3 otherChestCoord = chestCoord + vec3(int32(MAX_ENTITY_INFLUENCE_RADIUS) + 1, 0, 0);
 
     setupAirChunk(chestCoord);
 

--- a/packages/world/test/Tree.t.sol
+++ b/packages/world/test/Tree.t.sol
@@ -20,7 +20,7 @@ import { EntityPosition } from "../src/utils/Vec3Storage.sol";
 import {
   BUILD_ENERGY_COST,
   CHUNK_COMMIT_EXPIRY_BLOCKS,
-  MAX_ENTITY_INFLUENCE_HALF_WIDTH,
+  MAX_ENTITY_INFLUENCE_RADIUS,
   TILL_ENERGY_COST
 } from "../src/Constants.sol";
 

--- a/packages/world/worlds.json
+++ b/packages/world/worlds.json
@@ -8,7 +8,7 @@
     "blockNumber": 18361722
   },
   "31337": {
-    "address": "0xE5A77E7143588764bEDF8B1E20B3Ad5b71D8D865"
+    "address": "0x65e35992bac4274c0374746f6835D9D442660649"
   },
   "695569": {
     "address": "0xaa544E5e0D1C45cC43Ac8D5512a5081aA6Ca9EFE",


### PR DESCRIPTION
- New constant for max pickup range
- If mine coordinate is in pickup range, it is added to the player's inventory
- If not, it is dropped