### PR TITLE
Increase move limits

### DIFF
--- a/packages/world/src/Constants.sol
+++ b/packages/world/src/Constants.sol
@@ -6,7 +6,7 @@ uint32 constant MAX_PICKUP_RADIUS = 6;
 uint32 constant MAX_RESPAWN_HALF_WIDTH = 10;
 
 uint16 constant MAX_PLAYER_JUMPS = 3;
-uint16 constant MAX_PLAYER_GLIDES = 5;
+uint16 constant MAX_PLAYER_GLIDES = 10;
 uint16 constant PLAYER_SAFE_FALL_DISTANCE = 3;
 
 uint256 constant SPAWN_BLOCK_RANGE = 10;
@@ -48,8 +48,8 @@ uint128 constant PLAYER_FALL_ENERGY_COST = MAX_PLAYER_ENERGY / 25; // This makes
 
 uint128 constant MAX_MOVE_UNITS_PER_BLOCK = 1e18;
 uint128 constant MAX_MOVE_UNITS_PER_SECOND = MAX_MOVE_UNITS_PER_BLOCK / BLOCK_TIME; // 1e18 move units per second
-uint128 constant MOVING_UNIT_COST = MAX_MOVE_UNITS_PER_SECOND / 12; // 12 blocks per second
-uint128 constant SWIMMING_UNIT_COST = MAX_MOVE_UNITS_PER_SECOND * 10 / 108; // 10,8 blocks per second (90% of walking speed)
+uint128 constant MOVING_UNIT_COST = MAX_MOVE_UNITS_PER_SECOND / 15; // 15 blocks per second
+uint128 constant SWIMMING_UNIT_COST = MAX_MOVE_UNITS_PER_SECOND * 10 / 135; // 13,5 blocks per second (90% of walking speed)
 
 uint128 constant DEFAULT_ORE_TOOL_MULTIPLIER = 3;
 uint128 constant DEFAULT_WOODEN_TOOL_MULTIPLIER = 10;

--- a/packages/world/src/systems/libraries/MoveLib.sol
+++ b/packages/world/src/systems/libraries/MoveLib.sol
@@ -191,7 +191,7 @@ library MoveLib {
           require(jumps <= Constants.MAX_PLAYER_JUMPS, "Cannot jump more than 3 blocks");
         } else if (nextHasGravity) {
           ++glides;
-          require(glides <= Constants.MAX_PLAYER_GLIDES, "Cannot glide more than 5 blocks");
+          require(glides <= Constants.MAX_PLAYER_GLIDES, "Cannot glide more than 10 blocks");
         }
         (uint128 moveCost, uint128 moveUnits) = _getMoveCost(next);
         cost += moveCost;

--- a/packages/world/test/Move.t.sol
+++ b/packages/world/test/Move.t.sol
@@ -436,7 +436,7 @@ contract MoveTest is DustTest {
     }
 
     vm.prank(alice);
-    vm.expectRevert("Cannot glide more than 5 blocks");
+    vm.expectRevert("Cannot glide more than 10 blocks");
     world.move(aliceEntityId, newCoords);
   }
 
@@ -832,9 +832,9 @@ contract MoveTest is DustTest {
   function testWalkMoveUnits() public {
     (address alice, EntityId aliceEntityId, Vec3 playerCoord) = setupFlatChunkWithPlayer();
 
-    // Player can walk up to 24 blocks per Ethereum block
-    // Try to move 24 blocks, the next move should revert in the same block
-    Vec3[] memory newCoords = new Vec3[](24);
+    // Player can walk up to 30 blocks per Ethereum block
+    // Try to move 30 blocks, the next move should revert in the same block
+    Vec3[] memory newCoords = new Vec3[](30);
 
     Vec3 belowCoord;
 
@@ -849,7 +849,7 @@ contract MoveTest is DustTest {
     world.move(aliceEntityId, newCoords);
 
     newCoords = new Vec3[](1);
-    newCoords[0] = playerCoord + vec3(0, 0, 25);
+    newCoords[0] = playerCoord + vec3(0, 0, 31);
 
     belowCoord = newCoords[0] - vec3(0, 1, 0);
     setTerrainAtCoord(belowCoord, ObjectTypes.Grass);
@@ -859,7 +859,7 @@ contract MoveTest is DustTest {
     world.move(aliceEntityId, newCoords);
 
     Vec3 finalCoord = EntityPosition.get(aliceEntityId);
-    assertEq(finalCoord, playerCoord + vec3(0, 0, 24), "Player should have moved 24 blocks");
+    assertEq(finalCoord, playerCoord + vec3(0, 0, 30), "Player should have moved 30 blocks");
 
     // Move to next block and verify can move again
     vm.roll(block.number + 1);
@@ -878,9 +878,9 @@ contract MoveTest is DustTest {
   function testWaterMoveUnits() public {
     (address alice, EntityId aliceEntityId, Vec3 playerCoord) = setupWaterChunkWithPlayer();
 
-    // Player can swim up to ~21 blocks per Ethereum block in water
-    // Try to move 21 blocks, the next one should revert in the same block
-    Vec3[] memory newCoords = new Vec3[](21);
+    // Player can swim up to ~27 blocks per Ethereum block in water
+    // Try to move 27 blocks, the next one should revert in the same block
+    Vec3[] memory newCoords = new Vec3[](27);
 
     Vec3 belowCoord;
 
@@ -896,7 +896,7 @@ contract MoveTest is DustTest {
     world.move(aliceEntityId, newCoords);
 
     newCoords = new Vec3[](1);
-    newCoords[0] = playerCoord + vec3(0, 0, 22);
+    newCoords[0] = playerCoord + vec3(0, 0, 28);
 
     belowCoord = newCoords[0] - vec3(0, 1, 0);
     setTerrainAtCoord(newCoords[0], ObjectTypes.Water);
@@ -907,8 +907,8 @@ contract MoveTest is DustTest {
     world.move(aliceEntityId, newCoords);
 
     Vec3 finalCoord = EntityPosition.get(aliceEntityId);
-    // Should have moved 21 blocks
-    assertEq(finalCoord, playerCoord + vec3(0, 0, 21), "Player should have moved exactly 21 blocks in water");
+    // Should have moved 27 blocks
+    assertEq(finalCoord, playerCoord + vec3(0, 0, 27), "Player should have moved exactly 27 blocks in water");
 
     // Move to next block and verify can move again
     vm.roll(block.number + 1);


### PR DESCRIPTION
- Reverted decrease in max glides for now
- Made max moves per block 30, and max water moves 90% of that