### PR TITLE
Add overloaded functions that use msgSender instead of caller

### DIFF
--- a/packages/programs/src/DefaultProgramSystem.sol
+++ b/packages/programs/src/DefaultProgramSystem.sol
@@ -22,13 +22,6 @@ contract DefaultProgramSystem is System {
     return createAccessGroup(owner);
   }
 
-  function setAccessGroup(EntityId caller, EntityId target, uint256 groupId) public {
-    caller.validateCaller();
-    (uint256 currentGroupId,) = getGroupId(target);
-    _requireOwner(currentGroupId, caller);
-    EntityAccessGroup.set(target, groupId);
-  }
-
   /// @dev This function can be called by other entities to get a new access group assigned to themselves
   function setAccessGroup(EntityId caller, address groupOwner) external {
     caller.validateCaller();
@@ -39,10 +32,18 @@ contract DefaultProgramSystem is System {
     EntityAccessGroup.set(caller, groupId);
   }
 
+  /* Explicit caller (EntityId) */
+
+  function setAccessGroup(EntityId caller, EntityId target, uint256 groupId) public {
+    caller.validateCaller();
+    (uint256 currentGroupId,) = getGroupId(target);
+    _requireOwner(currentGroupId, caller);
+    EntityAccessGroup.set(target, groupId);
+  }
+
   function setMembership(EntityId caller, uint256 groupId, EntityId member, bool allowed) public {
     caller.validateCaller();
-    _requireOwner(groupId, caller);
-    AccessGroupMember.set(groupId, member, allowed);
+    _setMembership(caller, groupId, member, allowed);
   }
 
   function setMembership(EntityId caller, uint256 groupId, address member, bool allowed) external {
@@ -59,20 +60,49 @@ contract DefaultProgramSystem is System {
     setMembership(caller, target, EntityTypeLib.encodePlayer(member), allowed);
   }
 
-  function setOwner(EntityId caller, uint256 groupId, EntityId newOwner) external {
+  function setOwner(EntityId caller, uint256 groupId, EntityId newOwner) public {
     caller.validateCaller();
     _requireOwner(groupId, caller);
     AccessGroupOwner.set(groupId, newOwner);
   }
 
-  function setTextSignContent(EntityId caller, EntityId target, string memory content) external {
+  function setTextSignContent(EntityId caller, EntityId target, string memory content) public {
     caller.validateCaller();
     _requireMember(caller, target);
     TextSignContent.set(target, content);
   }
 
-  function getEntityGroupId(EntityId target) external view returns (uint256 groupId, bool defaultDeny) {
-    return getGroupId(target);
+  /* Implicit caller (_msgSender()) */
+
+  function setAccessGroup(EntityId target, uint256 groupId) public {
+    setAccessGroup(EntityTypeLib.encodePlayer(_msgSender()), target, groupId);
+  }
+
+  function setMembership(uint256 groupId, EntityId member, bool allowed) public {
+    _setMembership(EntityTypeLib.encodePlayer(_msgSender()), groupId, member, allowed);
+  }
+
+  function setMembership(uint256 groupId, address member, bool allowed) external {
+    setMembership(groupId, EntityTypeLib.encodePlayer(member), allowed);
+  }
+
+  function setMembership(EntityId target, EntityId member, bool allowed) public {
+    (uint256 groupId,) = getGroupId(target);
+    require(groupId != 0, "Target entity has no access group");
+    setMembership(groupId, member, allowed);
+  }
+
+  function setMembership(EntityId target, address member, bool allowed) external {
+    setMembership(target, EntityTypeLib.encodePlayer(member), allowed);
+  }
+
+  function setOwner(uint256 groupId, EntityId newOwner) external {
+    setOwner(EntityTypeLib.encodePlayer(_msgSender()), groupId, newOwner);
+  }
+
+  function setTextSignContent(EntityId target, string memory content) external {
+    EntityId caller = EntityTypeLib.encodePlayer(_msgSender());
+    setTextSignContent(caller, target, content);
   }
 
   function _requireMember(EntityId caller, EntityId target) private view {
@@ -81,5 +111,10 @@ contract DefaultProgramSystem is System {
 
   function _requireOwner(uint256 groupId, EntityId caller) private view {
     require(AccessGroupOwner.get(groupId) == caller, "Only the owner of the access group can call this function");
+  }
+
+  function _setMembership(EntityId caller, uint256 groupId, EntityId member, bool allowed) private {
+    _requireOwner(groupId, caller);
+    AccessGroupMember.set(groupId, member, allowed);
   }
 }

--- a/packages/programs/src/DefaultProgramSystem.sol
+++ b/packages/programs/src/DefaultProgramSystem.sol
@@ -34,6 +34,12 @@ contract DefaultProgramSystem is System {
 
   /* Explicit caller (EntityId) */
 
+  function setOwner(EntityId caller, uint256 groupId, EntityId newOwner) public {
+    caller.validateCaller();
+    _requireOwner(groupId, caller);
+    AccessGroupOwner.set(groupId, newOwner);
+  }
+
   function setAccessGroup(EntityId caller, EntityId target, uint256 groupId) public {
     caller.validateCaller();
     (uint256 currentGroupId,) = getGroupId(target);
@@ -60,12 +66,6 @@ contract DefaultProgramSystem is System {
     setMembership(caller, target, EntityTypeLib.encodePlayer(member), allowed);
   }
 
-  function setOwner(EntityId caller, uint256 groupId, EntityId newOwner) public {
-    caller.validateCaller();
-    _requireOwner(groupId, caller);
-    AccessGroupOwner.set(groupId, newOwner);
-  }
-
   function setTextSignContent(EntityId caller, EntityId target, string memory content) public {
     caller.validateCaller();
     _requireMember(caller, target);
@@ -73,6 +73,10 @@ contract DefaultProgramSystem is System {
   }
 
   /* Implicit caller (_msgSender()) */
+
+  function setOwner(uint256 groupId, EntityId newOwner) external {
+    setOwner(EntityTypeLib.encodePlayer(_msgSender()), groupId, newOwner);
+  }
 
   function setAccessGroup(EntityId target, uint256 groupId) public {
     setAccessGroup(EntityTypeLib.encodePlayer(_msgSender()), target, groupId);
@@ -94,10 +98,6 @@ contract DefaultProgramSystem is System {
 
   function setMembership(EntityId target, address member, bool allowed) external {
     setMembership(target, EntityTypeLib.encodePlayer(member), allowed);
-  }
-
-  function setOwner(uint256 groupId, EntityId newOwner) external {
-    setOwner(EntityTypeLib.encodePlayer(_msgSender()), groupId, newOwner);
   }
 
   function setTextSignContent(EntityId target, string memory content) external {

--- a/packages/programs/src/codegen/systems/DefaultProgramSystemLib.sol
+++ b/packages/programs/src/codegen/systems/DefaultProgramSystemLib.sol
@@ -42,12 +42,12 @@ library DefaultProgramSystemLib {
     return CallWrapper(self.toResourceId(), address(0)).newAccessGroup(owner);
   }
 
-  function setAccessGroup(DefaultProgramSystemType self, EntityId caller, EntityId target, uint256 groupId) internal {
-    return CallWrapper(self.toResourceId(), address(0)).setAccessGroup(caller, target, groupId);
-  }
-
   function setAccessGroup(DefaultProgramSystemType self, EntityId caller, address groupOwner) internal {
     return CallWrapper(self.toResourceId(), address(0)).setAccessGroup(caller, groupOwner);
+  }
+
+  function setAccessGroup(DefaultProgramSystemType self, EntityId caller, EntityId target, uint256 groupId) internal {
+    return CallWrapper(self.toResourceId(), address(0)).setAccessGroup(caller, target, groupId);
   }
 
   function setMembership(DefaultProgramSystemType self, EntityId caller, uint256 groupId, EntityId member, bool allowed)
@@ -84,12 +84,32 @@ library DefaultProgramSystemLib {
     return CallWrapper(self.toResourceId(), address(0)).setTextSignContent(caller, target, content);
   }
 
-  function getEntityGroupId(DefaultProgramSystemType self, EntityId target)
-    internal
-    view
-    returns (uint256 groupId, bool defaultDeny)
-  {
-    return CallWrapper(self.toResourceId(), address(0)).getEntityGroupId(target);
+  function setAccessGroup(DefaultProgramSystemType self, EntityId target, uint256 groupId) internal {
+    return CallWrapper(self.toResourceId(), address(0)).setAccessGroup(target, groupId);
+  }
+
+  function setMembership(DefaultProgramSystemType self, uint256 groupId, EntityId member, bool allowed) internal {
+    return CallWrapper(self.toResourceId(), address(0)).setMembership(groupId, member, allowed);
+  }
+
+  function setMembership(DefaultProgramSystemType self, uint256 groupId, address member, bool allowed) internal {
+    return CallWrapper(self.toResourceId(), address(0)).setMembership(groupId, member, allowed);
+  }
+
+  function setMembership(DefaultProgramSystemType self, EntityId target, EntityId member, bool allowed) internal {
+    return CallWrapper(self.toResourceId(), address(0)).setMembership(target, member, allowed);
+  }
+
+  function setMembership(DefaultProgramSystemType self, EntityId target, address member, bool allowed) internal {
+    return CallWrapper(self.toResourceId(), address(0)).setMembership(target, member, allowed);
+  }
+
+  function setOwner(DefaultProgramSystemType self, uint256 groupId, EntityId newOwner) internal {
+    return CallWrapper(self.toResourceId(), address(0)).setOwner(groupId, newOwner);
+  }
+
+  function setTextSignContent(DefaultProgramSystemType self, EntityId target, string memory content) internal {
+    return CallWrapper(self.toResourceId(), address(0)).setTextSignContent(target, content);
   }
 
   function newAccessGroup(CallWrapper memory self, EntityId owner) internal returns (uint256) {
@@ -104,22 +124,22 @@ library DefaultProgramSystemLib {
     return abi.decode(result, (uint256));
   }
 
+  function setAccessGroup(CallWrapper memory self, EntityId caller, address groupOwner) internal {
+    // if the contract calling this function is a root system, it should use `callAsRoot`
+    if (address(_world()) == address(this)) revert DefaultProgramSystemLib_CallingFromRootSystem();
+
+    bytes memory systemCall = abi.encodeCall(_setAccessGroup_EntityId_address.setAccessGroup, (caller, groupOwner));
+    self.from == address(0)
+      ? _world().call(self.systemId, systemCall)
+      : _world().callFrom(self.from, self.systemId, systemCall);
+  }
+
   function setAccessGroup(CallWrapper memory self, EntityId caller, EntityId target, uint256 groupId) internal {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert DefaultProgramSystemLib_CallingFromRootSystem();
 
     bytes memory systemCall =
       abi.encodeCall(_setAccessGroup_EntityId_EntityId_uint256.setAccessGroup, (caller, target, groupId));
-    self.from == address(0)
-      ? _world().call(self.systemId, systemCall)
-      : _world().callFrom(self.from, self.systemId, systemCall);
-  }
-
-  function setAccessGroup(CallWrapper memory self, EntityId caller, address groupOwner) internal {
-    // if the contract calling this function is a root system, it should use `callAsRoot`
-    if (address(_world()) == address(this)) revert DefaultProgramSystemLib_CallingFromRootSystem();
-
-    bytes memory systemCall = abi.encodeCall(_setAccessGroup_EntityId_address.setAccessGroup, (caller, groupOwner));
     self.from == address(0)
       ? _world().call(self.systemId, systemCall)
       : _world().callFrom(self.from, self.systemId, systemCall);
@@ -200,23 +220,78 @@ library DefaultProgramSystemLib {
       : _world().callFrom(self.from, self.systemId, systemCall);
   }
 
-  function getEntityGroupId(CallWrapper memory self, EntityId target)
-    internal
-    view
-    returns (uint256 groupId, bool defaultDeny)
-  {
+  function setAccessGroup(CallWrapper memory self, EntityId target, uint256 groupId) internal {
     // if the contract calling this function is a root system, it should use `callAsRoot`
     if (address(_world()) == address(this)) revert DefaultProgramSystemLib_CallingFromRootSystem();
 
-    bytes memory systemCall = abi.encodeCall(_getEntityGroupId_EntityId.getEntityGroupId, (target));
-    bytes memory worldCall = self.from == address(0)
-      ? abi.encodeCall(IWorldCall.call, (self.systemId, systemCall))
-      : abi.encodeCall(IWorldCall.callFrom, (self.from, self.systemId, systemCall));
-    (bool success, bytes memory returnData) = address(_world()).staticcall(worldCall);
-    if (!success) revertWithBytes(returnData);
+    bytes memory systemCall = abi.encodeCall(_setAccessGroup_EntityId_uint256.setAccessGroup, (target, groupId));
+    self.from == address(0)
+      ? _world().call(self.systemId, systemCall)
+      : _world().callFrom(self.from, self.systemId, systemCall);
+  }
 
-    bytes memory result = abi.decode(returnData, (bytes));
-    return abi.decode(result, (uint256, bool));
+  function setMembership(CallWrapper memory self, uint256 groupId, EntityId member, bool allowed) internal {
+    // if the contract calling this function is a root system, it should use `callAsRoot`
+    if (address(_world()) == address(this)) revert DefaultProgramSystemLib_CallingFromRootSystem();
+
+    bytes memory systemCall =
+      abi.encodeCall(_setMembership_uint256_EntityId_bool.setMembership, (groupId, member, allowed));
+    self.from == address(0)
+      ? _world().call(self.systemId, systemCall)
+      : _world().callFrom(self.from, self.systemId, systemCall);
+  }
+
+  function setMembership(CallWrapper memory self, uint256 groupId, address member, bool allowed) internal {
+    // if the contract calling this function is a root system, it should use `callAsRoot`
+    if (address(_world()) == address(this)) revert DefaultProgramSystemLib_CallingFromRootSystem();
+
+    bytes memory systemCall =
+      abi.encodeCall(_setMembership_uint256_address_bool.setMembership, (groupId, member, allowed));
+    self.from == address(0)
+      ? _world().call(self.systemId, systemCall)
+      : _world().callFrom(self.from, self.systemId, systemCall);
+  }
+
+  function setMembership(CallWrapper memory self, EntityId target, EntityId member, bool allowed) internal {
+    // if the contract calling this function is a root system, it should use `callAsRoot`
+    if (address(_world()) == address(this)) revert DefaultProgramSystemLib_CallingFromRootSystem();
+
+    bytes memory systemCall =
+      abi.encodeCall(_setMembership_EntityId_EntityId_bool.setMembership, (target, member, allowed));
+    self.from == address(0)
+      ? _world().call(self.systemId, systemCall)
+      : _world().callFrom(self.from, self.systemId, systemCall);
+  }
+
+  function setMembership(CallWrapper memory self, EntityId target, address member, bool allowed) internal {
+    // if the contract calling this function is a root system, it should use `callAsRoot`
+    if (address(_world()) == address(this)) revert DefaultProgramSystemLib_CallingFromRootSystem();
+
+    bytes memory systemCall =
+      abi.encodeCall(_setMembership_EntityId_address_bool.setMembership, (target, member, allowed));
+    self.from == address(0)
+      ? _world().call(self.systemId, systemCall)
+      : _world().callFrom(self.from, self.systemId, systemCall);
+  }
+
+  function setOwner(CallWrapper memory self, uint256 groupId, EntityId newOwner) internal {
+    // if the contract calling this function is a root system, it should use `callAsRoot`
+    if (address(_world()) == address(this)) revert DefaultProgramSystemLib_CallingFromRootSystem();
+
+    bytes memory systemCall = abi.encodeCall(_setOwner_uint256_EntityId.setOwner, (groupId, newOwner));
+    self.from == address(0)
+      ? _world().call(self.systemId, systemCall)
+      : _world().callFrom(self.from, self.systemId, systemCall);
+  }
+
+  function setTextSignContent(CallWrapper memory self, EntityId target, string memory content) internal {
+    // if the contract calling this function is a root system, it should use `callAsRoot`
+    if (address(_world()) == address(this)) revert DefaultProgramSystemLib_CallingFromRootSystem();
+
+    bytes memory systemCall = abi.encodeCall(_setTextSignContent_EntityId_string.setTextSignContent, (target, content));
+    self.from == address(0)
+      ? _world().call(self.systemId, systemCall)
+      : _world().callFrom(self.from, self.systemId, systemCall);
   }
 
   function newAccessGroup(RootCallWrapper memory self, EntityId owner) internal returns (uint256) {
@@ -226,14 +301,14 @@ library DefaultProgramSystemLib {
     return abi.decode(result, (uint256));
   }
 
-  function setAccessGroup(RootCallWrapper memory self, EntityId caller, EntityId target, uint256 groupId) internal {
-    bytes memory systemCall =
-      abi.encodeCall(_setAccessGroup_EntityId_EntityId_uint256.setAccessGroup, (caller, target, groupId));
+  function setAccessGroup(RootCallWrapper memory self, EntityId caller, address groupOwner) internal {
+    bytes memory systemCall = abi.encodeCall(_setAccessGroup_EntityId_address.setAccessGroup, (caller, groupOwner));
     SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
   }
 
-  function setAccessGroup(RootCallWrapper memory self, EntityId caller, address groupOwner) internal {
-    bytes memory systemCall = abi.encodeCall(_setAccessGroup_EntityId_address.setAccessGroup, (caller, groupOwner));
+  function setAccessGroup(RootCallWrapper memory self, EntityId caller, EntityId target, uint256 groupId) internal {
+    bytes memory systemCall =
+      abi.encodeCall(_setAccessGroup_EntityId_EntityId_uint256.setAccessGroup, (caller, target, groupId));
     SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
   }
 
@@ -282,15 +357,43 @@ library DefaultProgramSystemLib {
     SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
   }
 
-  function getEntityGroupId(RootCallWrapper memory self, EntityId target)
-    internal
-    view
-    returns (uint256 groupId, bool defaultDeny)
-  {
-    bytes memory systemCall = abi.encodeCall(_getEntityGroupId_EntityId.getEntityGroupId, (target));
+  function setAccessGroup(RootCallWrapper memory self, EntityId target, uint256 groupId) internal {
+    bytes memory systemCall = abi.encodeCall(_setAccessGroup_EntityId_uint256.setAccessGroup, (target, groupId));
+    SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
+  }
 
-    bytes memory result = SystemCall.staticcallOrRevert(self.from, self.systemId, systemCall);
-    return abi.decode(result, (uint256, bool));
+  function setMembership(RootCallWrapper memory self, uint256 groupId, EntityId member, bool allowed) internal {
+    bytes memory systemCall =
+      abi.encodeCall(_setMembership_uint256_EntityId_bool.setMembership, (groupId, member, allowed));
+    SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
+  }
+
+  function setMembership(RootCallWrapper memory self, uint256 groupId, address member, bool allowed) internal {
+    bytes memory systemCall =
+      abi.encodeCall(_setMembership_uint256_address_bool.setMembership, (groupId, member, allowed));
+    SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
+  }
+
+  function setMembership(RootCallWrapper memory self, EntityId target, EntityId member, bool allowed) internal {
+    bytes memory systemCall =
+      abi.encodeCall(_setMembership_EntityId_EntityId_bool.setMembership, (target, member, allowed));
+    SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
+  }
+
+  function setMembership(RootCallWrapper memory self, EntityId target, address member, bool allowed) internal {
+    bytes memory systemCall =
+      abi.encodeCall(_setMembership_EntityId_address_bool.setMembership, (target, member, allowed));
+    SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
+  }
+
+  function setOwner(RootCallWrapper memory self, uint256 groupId, EntityId newOwner) internal {
+    bytes memory systemCall = abi.encodeCall(_setOwner_uint256_EntityId.setOwner, (groupId, newOwner));
+    SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
+  }
+
+  function setTextSignContent(RootCallWrapper memory self, EntityId target, string memory content) internal {
+    bytes memory systemCall = abi.encodeCall(_setTextSignContent_EntityId_string.setTextSignContent, (target, content));
+    SystemCall.callWithHooksOrRevert(self.from, self.systemId, systemCall, msg.value);
   }
 
   function callFrom(DefaultProgramSystemType self, address from) internal pure returns (CallWrapper memory) {
@@ -334,12 +437,12 @@ interface _newAccessGroup_EntityId {
   function newAccessGroup(EntityId owner) external;
 }
 
-interface _setAccessGroup_EntityId_EntityId_uint256 {
-  function setAccessGroup(EntityId caller, EntityId target, uint256 groupId) external;
-}
-
 interface _setAccessGroup_EntityId_address {
   function setAccessGroup(EntityId caller, address groupOwner) external;
+}
+
+interface _setAccessGroup_EntityId_EntityId_uint256 {
+  function setAccessGroup(EntityId caller, EntityId target, uint256 groupId) external;
 }
 
 interface _setMembership_EntityId_uint256_EntityId_bool {
@@ -366,8 +469,32 @@ interface _setTextSignContent_EntityId_EntityId_string {
   function setTextSignContent(EntityId caller, EntityId target, string memory content) external;
 }
 
-interface _getEntityGroupId_EntityId {
-  function getEntityGroupId(EntityId target) external;
+interface _setAccessGroup_EntityId_uint256 {
+  function setAccessGroup(EntityId target, uint256 groupId) external;
+}
+
+interface _setMembership_uint256_EntityId_bool {
+  function setMembership(uint256 groupId, EntityId member, bool allowed) external;
+}
+
+interface _setMembership_uint256_address_bool {
+  function setMembership(uint256 groupId, address member, bool allowed) external;
+}
+
+interface _setMembership_EntityId_EntityId_bool {
+  function setMembership(EntityId target, EntityId member, bool allowed) external;
+}
+
+interface _setMembership_EntityId_address_bool {
+  function setMembership(EntityId target, address member, bool allowed) external;
+}
+
+interface _setOwner_uint256_EntityId {
+  function setOwner(uint256 groupId, EntityId newOwner) external;
+}
+
+interface _setTextSignContent_EntityId_string {
+  function setTextSignContent(EntityId target, string memory content) external;
 }
 
 using DefaultProgramSystemLib for DefaultProgramSystemType global;


### PR DESCRIPTION
Maybe we could remove some variants... though we used EntityId to make it possible for other entities to be able to manage access control

see https://github.com/dustproject/dust/issues/365